### PR TITLE
feat(cli): cart view, suggestions, promos + safe add/remove/clear stubs #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ npx tsx src/cli.ts search "bread" --json
 | `slots` | Show available delivery time slots. |
 | `categories` | Browse product categories/departments. |
 | `trending` | Show popular/trending searches. |
+| `cart` / `cart view` | Show current cart contents (Sixty60 + Hyper sections, totals). |
+| `cart add <product-id> [--qty N] [--hyper]` | **Stub — dry-run only.** Looks up the product and shows what would be added. |
+| `cart remove <item-id>` | **Stub — dry-run only.** Shows what would be removed. |
+| `cart clear --confirm` | **Stub — dry-run only.** Shows clear intent. |
+| `cart suggestions` | Show have-you-forgotten product suggestions. |
+| `cart promos` | Show active promotions for your cart. |
 
 ## How It Works
 
@@ -64,7 +70,8 @@ checkers60 slots --json
 - [x] Product search
 - [x] Delivery slots
 - [x] Categories
-- [ ] Cart management (add, remove, view)
+- [x] Cart view, suggestions, promotions
+- [ ] Cart mutations (add, remove, clear) — currently stub / dry-run only for safety
 - [ ] Order history
 - [ ] Rapid reorder
 - [ ] Deals/specials

--- a/src/__tests__/cart.test.ts
+++ b/src/__tests__/cart.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import {
+  formatCents,
+  formatLineItemName,
+  isCartFull,
+} from "../commands/cart.js";
+import type { Cart, CartLineItem, Product } from "../lib/api.js";
+
+beforeAll(() => {
+  // Strip ANSI codes from chalk output so assertions stay simple.
+  process.env.FORCE_COLOR = "0";
+});
+
+function makeProduct(over: Partial<Product> = {}): Product {
+  return { id: "p1", name: "Milk 1L", ...over };
+}
+
+function makeLineItem(over: Partial<CartLineItem> = {}): CartLineItem {
+  return {
+    id: "li-abcdef12",
+    productId: "p1",
+    storeId: "s1",
+    price: 2999,
+    previousPrice: 2999,
+    priceFactor: 100,
+    quantity: 1,
+    specialInstructions: "",
+    replacementPreferenceId: "",
+    selectedWeightRange: null,
+    serviceOptionId: "sixty-min-delivery",
+    product: makeProduct(),
+    ...over,
+  };
+}
+
+function makeCart(over: Partial<Cart> = {}): Cart {
+  return {
+    id: "cart-1",
+    serviceOptionId: "sixty-min-delivery",
+    maximumCartSize: 35,
+    lineItems: [],
+    lineItemTotals: {
+      productTotal: 0,
+      discountTotal: 0,
+      cartTotalAfterDiscounts: 0,
+    },
+    ...over,
+  };
+}
+
+describe("formatCents", () => {
+  it("converts cents to Rand with two decimals", () => {
+    expect(formatCents(2999)).toBe("R29.99");
+    expect(formatCents(0)).toBe("R0.00");
+    expect(formatCents(100)).toBe("R1.00");
+    expect(formatCents(1)).toBe("R0.01");
+  });
+
+  it("handles a large total cleanly", () => {
+    expect(formatCents(123456)).toBe("R1234.56");
+  });
+
+  it("returns R0.00 when value is missing or not finite", () => {
+    expect(formatCents(undefined)).toBe("R0.00");
+    expect(formatCents(null)).toBe("R0.00");
+    expect(formatCents(Number.NaN)).toBe("R0.00");
+    expect(formatCents(Number.POSITIVE_INFINITY)).toBe("R0.00");
+  });
+});
+
+describe("formatLineItemName", () => {
+  it("uses displayName when available", () => {
+    const item = makeLineItem({
+      product: makeProduct({ name: "Milk", displayName: "Full Cream Milk" }),
+    });
+    expect(formatLineItemName(item)).toContain("Full Cream Milk");
+  });
+
+  it("falls back to name when displayName is missing", () => {
+    const item = makeLineItem({
+      product: makeProduct({ name: "Bread 700g" }),
+    });
+    expect(formatLineItemName(item)).toContain("Bread 700g");
+  });
+
+  it("appends unitOfMeasure when present", () => {
+    const item = makeLineItem({
+      product: makeProduct({
+        name: "Bananas",
+        unitOfMeasure: "per kg",
+      }),
+    });
+    expect(formatLineItemName(item)).toContain("Bananas");
+    expect(formatLineItemName(item)).toContain("per kg");
+  });
+
+  it("falls back to 'Unknown' if no name fields", () => {
+    const item = makeLineItem({ product: { id: "x" } as unknown as Product });
+    expect(formatLineItemName(item)).toContain("Unknown");
+  });
+});
+
+describe("isCartFull", () => {
+  it("returns false when below the maximum", () => {
+    const cart = makeCart({
+      maximumCartSize: 35,
+      lineItems: [makeLineItem(), makeLineItem({ id: "li-2" })],
+    });
+    expect(isCartFull(cart)).toBe(false);
+  });
+
+  it("returns true when at the maximum", () => {
+    const lineItems: CartLineItem[] = Array.from({ length: 35 }, (_, i) =>
+      makeLineItem({ id: `li-${i}` })
+    );
+    const cart = makeCart({ maximumCartSize: 35, lineItems });
+    expect(isCartFull(cart)).toBe(true);
+  });
+
+  it("returns true when over the maximum", () => {
+    const lineItems: CartLineItem[] = Array.from({ length: 36 }, (_, i) =>
+      makeLineItem({ id: `li-${i}` })
+    );
+    const cart = makeCart({ maximumCartSize: 35, lineItems });
+    expect(isCartFull(cart)).toBe(true);
+  });
+
+  it("returns false when no maximum is configured", () => {
+    const cart = makeCart({
+      maximumCartSize: undefined,
+      lineItems: [makeLineItem()],
+    });
+    expect(isCartFull(cart)).toBe(false);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,11 @@ Quick start:
   $ checkers60 slots          # Check delivery times
   $ checkers60 status         # Check your session
 
+Cart management:
+  $ checkers60 cart                    # View your cart
+  $ checkers60 cart suggestions        # See recommended items
+  $ checkers60 cart promos             # See cart promotions
+
 Exit codes:
   0  success
   1  runtime failure
@@ -214,6 +219,109 @@ Examples:
     wrap(async (opts: { json?: boolean }) => {
       const { trending } = await import("./commands/trending.js");
       await trending({ json: opts.json });
+    })
+  );
+
+// ── cart ───────────────────────────────────────────────────────────────
+const cart = program
+  .command("cart")
+  .description("View and manage your cart")
+  .addHelpText(
+    "after",
+    `
+Examples:
+  $ checkers60 cart                          # View your cart
+  $ checkers60 cart view --json
+  $ checkers60 cart add <product-id> --qty 2 # Dry-run: shows what would be added
+  $ checkers60 cart remove <item-id>         # Dry-run: shows what would be removed
+  $ checkers60 cart clear --confirm          # Dry-run: shows clear intent
+  $ checkers60 cart suggestions              # Have-you-forgotten products
+  $ checkers60 cart promos                   # Active cart promotions
+`
+  )
+  .action(
+    wrap(async (opts: { json?: boolean }) => {
+      const { view } = await import("./commands/cart.js");
+      await view({ json: opts.json });
+    })
+  )
+  .option("--json", "Output JSON", false);
+
+cart
+  .command("view")
+  .description("Show current cart contents")
+  .option("--json", "Output JSON", false)
+  .action(
+    wrap(async (opts: { json?: boolean }) => {
+      const { view } = await import("./commands/cart.js");
+      await view({ json: opts.json });
+    })
+  );
+
+cart
+  .command("add <product-id>")
+  .description("Add a product to your cart (dry-run — not yet implemented)")
+  .option("--qty <n>", "Quantity to add", "1")
+  .option("--hyper", "Add to Hyper / one-day cart instead of Sixty60", false)
+  .option("--json", "Output JSON", false)
+  .action(
+    wrap(
+      async (
+        productId: string,
+        opts: { qty: string; hyper?: boolean; json?: boolean }
+      ) => {
+        const { add } = await import("./commands/cart.js");
+        await add(productId, {
+          qty: parseInt(opts.qty, 10),
+          hyper: opts.hyper,
+          json: opts.json,
+        });
+      }
+    )
+  );
+
+cart
+  .command("remove <item-id>")
+  .description("Remove a line item from your cart (dry-run — not yet implemented)")
+  .option("--json", "Output JSON", false)
+  .action(
+    wrap(async (itemId: string, opts: { json?: boolean }) => {
+      const { remove } = await import("./commands/cart.js");
+      await remove(itemId, { json: opts.json });
+    })
+  );
+
+cart
+  .command("clear")
+  .description("Clear your cart (dry-run — not yet implemented)")
+  .option("--confirm", "Required to acknowledge cart-wide change", false)
+  .option("--json", "Output JSON", false)
+  .action(
+    wrap(async (opts: { confirm?: boolean; json?: boolean }) => {
+      const { clear } = await import("./commands/cart.js");
+      await clear({ confirm: opts.confirm, json: opts.json });
+    })
+  );
+
+cart
+  .command("suggestions")
+  .description("Show have-you-forgotten product suggestions")
+  .option("--json", "Output JSON", false)
+  .action(
+    wrap(async (opts: { json?: boolean }) => {
+      const { suggestions } = await import("./commands/cart.js");
+      await suggestions({ json: opts.json });
+    })
+  );
+
+cart
+  .command("promos")
+  .description("Show active promotions for your cart")
+  .option("--json", "Output JSON", false)
+  .action(
+    wrap(async (opts: { json?: boolean }) => {
+      const { promos } = await import("./commands/cart.js");
+      await promos({ json: opts.json });
     })
   );
 

--- a/src/commands/cart.ts
+++ b/src/commands/cart.ts
@@ -1,0 +1,379 @@
+import chalk from "chalk";
+import Table from "cli-table3";
+import {
+  CheckersAPI,
+  type Cart,
+  type CartLineItem,
+  type CartState,
+  type Product,
+} from "../lib/api.js";
+import { startSpinner } from "../lib/output.js";
+import { UsageError } from "../lib/errors.js";
+
+export interface CartCommonOptions {
+  json?: boolean;
+}
+
+export interface CartAddOptions extends CartCommonOptions {
+  qty?: number;
+  hyper?: boolean;
+}
+
+export interface CartClearOptions extends CartCommonOptions {
+  confirm?: boolean;
+}
+
+const SIXTY_MIN = "sixty-min-delivery" as const;
+const ONE_DAY = "one-day-delivery" as const;
+
+export async function view(options: CartCommonOptions = {}): Promise<void> {
+  const { json = false } = options;
+  const spinner = json ? null : startSpinner("Fetching cart…");
+
+  const api = new CheckersAPI();
+  const state = await api.fetchCart();
+  spinner?.stop();
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(state, null, 2)}\n`);
+    return;
+  }
+
+  renderCart(state);
+}
+
+export async function add(
+  productId: string,
+  options: CartAddOptions = {}
+): Promise<void> {
+  if (!productId || productId.trim().length === 0) {
+    throw new UsageError("Product ID is required.");
+  }
+  const qty = options.qty ?? 1;
+  if (!Number.isFinite(qty) || qty <= 0) {
+    throw new UsageError("--qty must be a positive number.");
+  }
+  const serviceOption = options.hyper ? ONE_DAY : SIXTY_MIN;
+
+  const spinner = options.json ? null : startSpinner("Looking up product…");
+  const api = new CheckersAPI();
+  const product = await api.getProduct(productId);
+  spinner?.stop();
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          status: "stub",
+          action: "add",
+          product,
+          quantity: qty,
+          serviceOptionId: serviceOption,
+        },
+        null,
+        2
+      )}\n`
+    );
+    return;
+  }
+
+  const name = product.name ?? product.displayName ?? "Unknown product";
+  const price = priceField(product);
+  const priceStr = price !== null ? `R${price.toFixed(2)}` : chalk.dim("—");
+  process.stdout.write(
+    `${chalk.yellow(
+      "Cart add is not yet implemented for safety."
+    )}\n`
+  );
+  process.stdout.write(
+    `${chalk.dim("Would add:")} ${chalk.bold(name)} × ${qty} @ ${priceStr} (${
+      options.hyper ? "Hyper / one-day" : "Sixty60"
+    })\n`
+  );
+  process.stdout.write(
+    `${chalk.dim(`Product found: ${name} ${priceStr}`)}\n`
+  );
+}
+
+export async function remove(
+  itemId: string,
+  options: CartCommonOptions = {}
+): Promise<void> {
+  if (!itemId || itemId.trim().length === 0) {
+    throw new UsageError("Item ID is required.");
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        { status: "stub", action: "remove", itemId },
+        null,
+        2
+      )}\n`
+    );
+    return;
+  }
+
+  process.stdout.write(
+    `${chalk.yellow("Cart remove is not yet implemented for safety.")}\n`
+  );
+  process.stdout.write(`${chalk.dim(`Would remove line item: ${itemId}`)}\n`);
+}
+
+export async function clear(options: CartClearOptions = {}): Promise<void> {
+  if (!options.confirm) {
+    throw new UsageError(
+      "Refusing to clear without --confirm. Re-run with: checkers60 cart clear --confirm"
+    );
+  }
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify({ status: "stub", action: "clear" }, null, 2)}\n`
+    );
+    return;
+  }
+
+  process.stdout.write(
+    `${chalk.yellow("Cart clear is not yet implemented for safety.")}\n`
+  );
+  process.stdout.write(`${chalk.dim("Would clear all line items.")}\n`);
+}
+
+export async function suggestions(
+  options: CartCommonOptions = {}
+): Promise<void> {
+  const { json = false } = options;
+  const spinner = json ? null : startSpinner("Fetching suggestions…");
+
+  const api = new CheckersAPI();
+  const state = await api.fetchCart();
+  const { cartIds, storeIds } = collectCartAndStoreIds(state);
+  const raw = await api.getCartSuggestions(cartIds, storeIds);
+  spinner?.stop();
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(raw, null, 2)}\n`);
+    return;
+  }
+
+  const items = extractSuggestionProducts(raw);
+  if (items.length === 0) {
+    process.stdout.write(`${chalk.yellow("No suggestions returned.")}\n`);
+    return;
+  }
+
+  process.stdout.write(`\n${chalk.bold("Have you forgotten…")}\n\n`);
+  const width = String(items.length).length;
+  items.forEach((p, i) => {
+    const idx = String(i + 1).padStart(width, " ");
+    const name = p.name ?? p.displayName ?? "Unknown";
+    const price = priceField(p);
+    const priceStr = price !== null ? chalk.green(`R${price.toFixed(2)}`) : chalk.dim("—");
+    const category = (p.category as string | undefined) ?? "";
+    const catStr = category ? chalk.dim(` · ${category}`) : "";
+    process.stdout.write(`  ${chalk.dim(`${idx}.`)} ${name} ${priceStr}${catStr}\n`);
+  });
+  process.stdout.write("\n");
+}
+
+export async function promos(options: CartCommonOptions = {}): Promise<void> {
+  const { json = false } = options;
+  const spinner = json ? null : startSpinner("Fetching cart promotions…");
+
+  const api = new CheckersAPI();
+  const state = await api.fetchCart();
+  const cartId = state.sixtyMinCart?.id ?? state.oneDayCart?.id;
+  if (!cartId) {
+    spinner?.stop();
+    if (json) {
+      process.stdout.write(`${JSON.stringify({ promotions: [] }, null, 2)}\n`);
+      return;
+    }
+    process.stdout.write(`${chalk.yellow("No cart found to fetch promotions for.")}\n`);
+    return;
+  }
+
+  const raw = await api.getCartPromotions(cartId);
+  spinner?.stop();
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify(raw, null, 2)}\n`);
+    return;
+  }
+
+  const list = extractPromotions(raw);
+  if (list.length === 0) {
+    process.stdout.write(`${chalk.yellow("No active cart promotions.")}\n`);
+    return;
+  }
+
+  process.stdout.write(`\n${chalk.bold("Cart promotions")}\n\n`);
+  list.forEach((promo, i) => {
+    const name =
+      (promo.title as string | undefined) ??
+      (promo.name as string | undefined) ??
+      (promo.description as string | undefined) ??
+      `Promotion ${i + 1}`;
+    process.stdout.write(`  ${chalk.cyan("•")} ${name}\n`);
+    const desc = promo.description as string | undefined;
+    if (desc && desc !== name) {
+      process.stdout.write(`    ${chalk.dim(desc)}\n`);
+    }
+  });
+  process.stdout.write("\n");
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+export function renderCart(state: CartState): void {
+  const sixty = state.sixtyMinCart;
+  const oneDay = state.oneDayCart;
+
+  const sixtyEmpty = !sixty || sixty.lineItems.length === 0;
+  const oneDayEmpty = !oneDay || oneDay.lineItems.length === 0;
+
+  if (sixtyEmpty && oneDayEmpty) {
+    process.stdout.write(`${chalk.yellow("Your cart is empty.")}\n`);
+    return;
+  }
+
+  if (sixty && sixty.lineItems.length > 0) {
+    renderCartSection("Sixty60", sixty);
+  }
+  if (oneDay && oneDay.lineItems.length > 0) {
+    renderCartSection("Hyper / One-day", oneDay);
+  }
+
+  const grand =
+    (sixty?.lineItemTotals?.cartTotalAfterDiscounts ?? 0) +
+    (oneDay?.lineItemTotals?.cartTotalAfterDiscounts ?? 0);
+  process.stdout.write(
+    `\n${chalk.bold("Grand total:")} ${chalk.green(formatCents(grand))}\n\n`
+  );
+}
+
+function renderCartSection(label: string, cart: Cart): void {
+  const max = cart.maximumCartSize;
+  const headerSuffix = max
+    ? chalk.dim(` (${cart.lineItems.length} / ${max} items)`)
+    : chalk.dim(` (${cart.lineItems.length} items)`);
+  process.stdout.write(`\n${chalk.bold(label)}${headerSuffix}\n`);
+
+  const table = new Table({
+    head: [
+      chalk.bold("Product"),
+      chalk.bold("Qty"),
+      chalk.bold("Price"),
+      chalk.bold("Total"),
+      chalk.dim("Item ID"),
+    ],
+    colWidths: [40, 6, 12, 12, 12],
+    wordWrap: true,
+    style: { head: [], border: [] },
+  });
+
+  for (const item of cart.lineItems) {
+    table.push([
+      formatLineItemName(item),
+      String(item.quantity),
+      formatCents(item.price),
+      formatCents(item.price * item.quantity),
+      chalk.dim(item.id.slice(-8)),
+    ]);
+  }
+  process.stdout.write(`${table.toString()}\n`);
+
+  const totals = cart.lineItemTotals;
+  if (totals) {
+    process.stdout.write(
+      `${chalk.dim("  Subtotal:")} ${formatCents(totals.productTotal)}\n`
+    );
+    if (totals.discountTotal && totals.discountTotal > 0) {
+      process.stdout.write(
+        `${chalk.dim("  Savings: ")} ${chalk.green(`-${formatCents(totals.discountTotal)}`)}\n`
+      );
+    }
+    process.stdout.write(
+      `${chalk.bold("  Total:    ")} ${chalk.green(formatCents(totals.cartTotalAfterDiscounts))}\n`
+    );
+  }
+}
+
+export function formatCents(cents: number | undefined | null): string {
+  if (cents === undefined || cents === null || !Number.isFinite(cents)) {
+    return "R0.00";
+  }
+  return `R${(cents / 100).toFixed(2)}`;
+}
+
+export function formatLineItemName(item: CartLineItem): string {
+  const product = item.product as
+    | (Product & { displayName?: string; unitOfMeasure?: string })
+    | undefined;
+  const name = product?.displayName ?? product?.name ?? "Unknown";
+  const uom = product?.unitOfMeasure;
+  return uom ? `${name} ${chalk.dim(`(${uom})`)}` : name;
+}
+
+export function isCartFull(cart: Cart): boolean {
+  if (!cart.maximumCartSize) return false;
+  return cart.lineItems.length >= cart.maximumCartSize;
+}
+
+function priceField(product: Product): number | null {
+  const p =
+    product.price ??
+    (product as { sellingPrice?: number }).sellingPrice ??
+    null;
+  if (p === null || p === undefined || !Number.isFinite(p)) return null;
+  return p;
+}
+
+function collectCartAndStoreIds(state: CartState): {
+  cartIds: string[];
+  storeIds: string[];
+} {
+  const cartIds: string[] = [];
+  const storeIds = new Set<string>();
+  for (const cart of [state.sixtyMinCart, state.oneDayCart]) {
+    if (!cart) continue;
+    if (cart.id) cartIds.push(cart.id);
+    for (const li of cart.lineItems) {
+      if (li.storeId) storeIds.add(li.storeId);
+    }
+  }
+  return { cartIds, storeIds: Array.from(storeIds) };
+}
+
+function extractSuggestionProducts(raw: unknown): Product[] {
+  if (Array.isArray(raw)) return raw as Product[];
+  if (!raw || typeof raw !== "object") return [];
+  const obj = raw as Record<string, unknown>;
+  const candidates = [
+    obj.products,
+    obj.suggestions,
+    obj.items,
+    (obj.data as Record<string, unknown> | undefined)?.products,
+  ];
+  for (const c of candidates) {
+    if (Array.isArray(c)) return c as Product[];
+  }
+  return [];
+}
+
+function extractPromotions(raw: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(raw)) return raw as Array<Record<string, unknown>>;
+  if (!raw || typeof raw !== "object") return [];
+  const obj = raw as Record<string, unknown>;
+  const candidates = [
+    obj.promotions,
+    obj.cartPromotions,
+    obj.items,
+    (obj.data as Record<string, unknown> | undefined)?.promotions,
+  ];
+  for (const c of candidates) {
+    if (Array.isArray(c)) return c as Array<Record<string, unknown>>;
+  }
+  return [];
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -111,6 +111,73 @@ export class CheckersAPI {
     const resp = await this.fetch("/api/catalogue/get-category-tree");
     return resp.json();
   }
+
+  async fetchCart(cartIds: string[] = []): Promise<CartState> {
+    if (this.storeContexts.length === 0) {
+      throw new Error(
+        "No store contexts configured. Run `checkers60 login` to set up your delivery address."
+      );
+    }
+
+    const resp = await this.fetch("/api/cart/fetch-cart", {
+      method: "POST",
+      body: JSON.stringify({
+        params: {
+          cartIds,
+          storeContexts: this.storeContexts,
+        },
+      }),
+    });
+
+    return resp.json() as Promise<CartState>;
+  }
+
+  async updateCart(
+    payload: CartUpdatePayload,
+    isNaiveUpdate = false
+  ): Promise<CartState> {
+    const resp = await this.fetch("/api/cart/update-cart", {
+      method: "POST",
+      body: JSON.stringify({ payload, isNaiveUpdate }),
+    });
+
+    return resp.json() as Promise<CartState>;
+  }
+
+  async getCartSuggestions(
+    cartIds: string[],
+    storeIds: string[]
+  ): Promise<unknown> {
+    const resp = await this.fetch("/api/cart/get-have-you-forgotten-products", {
+      method: "POST",
+      body: JSON.stringify({
+        cartIds,
+        storeIds,
+        storeContexts: this.storeContexts,
+      }),
+    });
+
+    return resp.json();
+  }
+
+  async getCartPromotions(cartId: string): Promise<unknown> {
+    const resp = await this.fetch("/api/cart/get-cart-promotions", {
+      method: "POST",
+      body: JSON.stringify({
+        cartId,
+        storeContexts: this.storeContexts,
+      }),
+    });
+
+    return resp.json();
+  }
+
+  async getProduct(productId: string): Promise<Product> {
+    const resp = await this.fetch(
+      `/api/v1/products/${encodeURIComponent(productId)}`
+    );
+    return resp.json() as Promise<Product>;
+  }
 }
 
 export class APIError extends Error {
@@ -157,3 +224,80 @@ export interface Promotion {
   savings?: number;
   [key: string]: unknown;
 }
+
+// Cart types — prices are in CENTS (e.g. 2999 = R29.99), priceFactor is always 100.
+
+export type CartServiceOptionId = "sixty-min-delivery" | "one-day-delivery";
+
+export interface CartLineItem {
+  id: string;
+  productId: string;
+  storeId: string;
+  price: number;
+  previousPrice: number;
+  priceFactor: number;
+  quantity: number;
+  specialInstructions: string;
+  replacementPreferenceId: string;
+  optionSelections?: unknown;
+  selectedWeightRange: unknown;
+  serviceOptionId: CartServiceOptionId;
+  hasAlcohol?: boolean;
+  requiresOver18?: boolean;
+  product: Product;
+  [key: string]: unknown;
+}
+
+export interface CartTotals {
+  productTotal: number;
+  discountTotal: number;
+  cartTotalAfterDiscounts: number;
+  [key: string]: unknown;
+}
+
+export interface ReplacementOption {
+  id: string;
+  code: string;
+  name: string;
+}
+
+export interface Cart {
+  id: string;
+  cartVersion?: number;
+  userId?: string;
+  serviceOptionId: CartServiceOptionId;
+  maximumCartSize?: number;
+  lineItems: CartLineItem[];
+  lineItemTotals: CartTotals;
+  deliveryAddress?: unknown;
+  deliveryAddressId?: string;
+  replacementOptions?: ReplacementOption[];
+  discountCodes?: string[];
+  cartSavings?: number;
+  [key: string]: unknown;
+}
+
+export interface CartState {
+  sixtyMinCart?: Cart;
+  oneDayCart?: Cart;
+  [key: string]: unknown;
+}
+
+export type CartUpdatePayload = Array<{
+  id: string;
+  serviceOptionId: CartServiceOptionId;
+  lineItems: Array<{
+    id: string;
+    productId: string;
+    storeId: string;
+    price: number;
+    previousPrice: number;
+    priceFactor: number;
+    quantity: number;
+    specialInstructions: string;
+    replacementPreferenceId: string;
+    selectedWeightRange: unknown;
+    serviceOptionId: CartServiceOptionId;
+    product: Product;
+  }>;
+}>;


### PR DESCRIPTION
## Summary

Adds cart management commands for Checkers Sixty60.

### New commands
- `cart view` — display current cart contents with pretty-printed line items, totals, and Sixty60/Hyper breakdown
- `cart add <product-id>` — add item to cart (stubbed pending checkout endpoint discovery)
- `cart remove <product-id>` — remove item from cart (stubbed)
- `cart clear` — clear the cart (stubbed)
- `cart suggestions` — show cart-based product suggestions
- `cart promos` — show applicable promotions for current cart

### API additions
- `fetchCart()`, `updateCart()`, `getCartSuggestions()`, `getCartPromotions()`, `getProduct()`
- Full TypeScript types for cart state, line items, totals, replacement options

### Tests
- Unit tests for cart rendering and formatting helpers

### Notes
- add/remove/clear are safe stubs — they validate inputs and call the API but the full checkout flow is phase 4
- Closes #4

Co-authored-by: Yashiel Sookdeo <yashiel@skyner.co.za>