### PR TITLE
docs(scaffold): add AGENTS.md, Makefile, steipete format alignment #7

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "semi": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,97 @@
+# AGENTS.md — checkers60
+
+Checkers Sixty60 grocery CLI. TypeScript, talks directly to the Sixty60 mobile-app API (reverse-engineered Android APK).
+
+## Directory Structure
+
+```
+.
+├── .github/
+│   └── workflows/
+│       ├── ci.yml              # Lint + test on push to main
+│       ├── release-impl.yml    # Reusable release implementation
+│       └── ship.yml            # Version bump + GitHub Release + Homebrew tap
+├── docs/
+│   └── assets/                 # Static docs assets
+├── src/
+│   ├── __tests__/
+│   │   ├── format.test.ts      # Output formatting tests
+│   │   └── http.test.ts        # HTTP client tests
+│   ├── commands/
+│   │   ├── add.ts              # Add item to cart
+│   │   ├── addresses.ts        # List delivery addresses
+│   │   ├── cards.ts            # List payment cards
+│   │   ├── cart.ts             # View cart
+│   │   ├── categories.ts       # Browse categories
+│   │   ├── clear.ts            # Clear cart
+│   │   ├── login.ts            # OTP login initiation
+│   │   ├── logout.ts           # Clear stored credentials
+│   │   ├── orders.ts           # View orders
+│   │   ├── profile.ts          # Show user profile
+│   │   ├── remove.ts           # Remove item from cart
+│   │   ├── search.ts           # Search products
+│   │   ├── slots.ts            # List delivery slots
+│   │   ├── status.ts           # Account status overview
+│   │   └── trending.ts         # Trending products
+│   ├── lib/
+│   │   ├── api.ts              # Sixty60 API client (all endpoints)
+│   │   ├── config.ts           # App configuration constants
+│   │   ├── credentials.ts      # Token storage + refresh logic
+│   │   ├── errors.ts           # Typed error classes
+│   │   ├── format.ts           # Table/human-readable output helpers
+│   │   ├── http.ts             # Authenticated HTTP wrapper
+│   │   └── output.ts           # --json / --quiet output routing
+│   └── cli.ts                  # Commander entry point, registers all commands
+├── .gitignore
+├── .prettierrc                 # Prettier formatting config
+├── AGENTS.md                   # This file
+├── CHANGELOG.md
+├── LICENSE
+├── Makefile                    # Standard make targets (ci, lint, test, build, fmt, clean)
+├── README.md
+├── package.json
+├── tsconfig.json
+└── version.env                 # Current version string (used by ship.yml)
+```
+
+## Build / Test / Lint
+
+```bash
+make install   # npm install (idempotent)
+make fmt       # prettier --write . (format all files)
+make lint      # tsc --noEmit (type-check only, no emit)
+make test      # vitest run
+make build     # tsup → dist/ (ESM + DTS)
+make ci        # lint + test (what CI runs)
+make clean     # rm -rf dist
+```
+
+Run `make ci` before every commit. It is the gate for CI.
+
+## Key Design Decisions
+
+- **Direct API** — calls the Sixty60 mobile-app REST API reverse-engineered from the Android APK. No browser automation, no Playwright, no scraping.
+- **OTP login** — two-step: `login` sends an OTP to the user's phone, `otp-verify` (or the prompted flow) completes auth. Access + refresh tokens are cached to `~/.openclaw/credentials/checkers60.json` and auto-refreshed on expiry.
+- **TSup build** — emits ESM (`dist/cli.js`) with `.d.ts` types. Configured via the `build` script in `package.json`; no separate `tsup.config` file.
+- **Commander CLI** — `src/cli.ts` is the root Commander program. Each command lives in `src/commands/` and is registered there.
+- **JSON output** — every data command exposes `--json`. Use `output.ts` helpers (`printJson` / `printTable`) to route output; never `console.log` raw objects in commands.
+
+## Constraints
+
+- **No browser automation** — do not add Playwright, Puppeteer, or any browser-based auth.
+- **Do not change the OTP auth flow** — the two-step phone + SMS code flow is intentional; do not simplify or replace it.
+- **Credentials path is `~/.openclaw/credentials/checkers60.json`** — do not change this path or the token schema without updating `credentials.ts` and docs.
+- **Keep `--json` on every data command** — scripting and agent integration depend on it.
+- **No `console.log` in commands** — use `output.ts` helpers so `--quiet` and `--json` flags work correctly.
+
+## CI
+
+| Workflow      | Trigger                    | What it does                                      |
+|---------------|----------------------------|---------------------------------------------------|
+| `ci.yml`      | Push / PR to `main`        | `tsc --noEmit` + `vitest run`                     |
+| `ship.yml`    | Manual `workflow_dispatch`  | Version bump, GitHub Release, Homebrew tap update |
+
+Run CI locally with:
+```bash
+make ci
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+(nothing yet)
+
 ## [0.1.0] — 2026-06-08
 
 Initial release.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: install fmt lint test build ci clean
+
+node_modules: package.json
+	npm install
+
+install: node_modules
+
+fmt: node_modules
+	npm run fmt
+
+lint: node_modules
+	npm run lint
+
+test: node_modules
+	npm run test
+
+build: node_modules
+	npm run build
+
+ci: lint test
+
+clean:
+	rm -rf dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "checkers60-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "checkers60-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "prettier": "^3.8.4",
         "tsup": "^8.5.0",
         "tsx": "^4.19.0",
         "typescript": "^5.8.0",
@@ -1797,6 +1798,22 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsup src/cli.ts --format esm --dts --clean",
     "dev": "tsx src/cli.ts",
+    "fmt": "prettier --write .",
     "lint": "tsc --noEmit",
     "test": "vitest run --passWithNoTests"
   },
@@ -26,16 +27,17 @@
     "node": ">=20"
   },
   "dependencies": {
-    "commander": "^13.1.0",
     "chalk": "^5.4.1",
-    "ora": "^8.2.0",
-    "cli-table3": "^0.6.5"
+    "cli-table3": "^0.6.5",
+    "commander": "^13.1.0",
+    "ora": "^8.2.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
+    "prettier": "^3.8.4",
     "tsup": "^8.5.0",
     "tsx": "^4.19.0",
     "typescript": "^5.8.0",
-    "vitest": "^3.2.0",
-    "@types/node": "^22.0.0"
+    "vitest": "^3.2.0"
   }
 }


### PR DESCRIPTION
## Summary

- **AGENTS.md** — full project guide for agentic development: directory tree, build/test/lint targets, key design decisions, constraints, and CI table
- **Makefile** — standard `make` targets: `install`, `fmt`, `lint`, `test`, `build`, `ci`, `clean`; `make ci` is the local gate matching what CI runs
- **.prettierrc** — `singleQuote`, `trailingComma: all`, `printWidth: 100`, `semi: true`
- **package.json** — adds `fmt` script (`prettier --write .`) and `prettier` as a devDependency
- **CHANGELOG.md** — inserts `## Unreleased` section above the first version entry

Prettier was checked (`--check`) — 29 source files are flagged for reformatting, which is expected on first install. The actual format pass is intentionally deferred to a follow-up commit to keep this PR reviewable.

## Test plan

- [x] `make ci` passes locally (tsc --noEmit clean, 18/18 vitest tests pass)
- [x] `make lint` passes
- [x] `make test` passes
- [x] `npx prettier --check .` exits non-zero only for style (no parse errors)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)