### PR TITLE
chore(ci): pin pr-agent to skynergroup/.github@main

### DIFF
--- a/.github/workflows/pr-agent.yml
+++ b/.github/workflows/pr-agent.yml
@@ -10,6 +10,6 @@ permissions:
   contents: read
 jobs:
   review:
-    uses: skynergroup/.github/.github/workflows/pr-agent.yml@e5d65d05cdd00cdec39dff9fd3a7c32d5a41931b
+    uses: skynergroup/.github/.github/workflows/pr-agent.yml@main
     secrets:
       KIMI_API_KEY: ${{ secrets.KIMI_API_KEY }}


### PR DESCRIPTION
### **User description**
Repoint pr-agent caller from pinned SHA (e5d65d0, broken secret syntax) to skynergroup/.github@main. Fixes the broken pr-agent AND bakes in ai_timeout=600 + max_model_tokens=200000 via the shared workflow. Key stays repo-level.


___

### **PR Type**
Other


___

### **Description**
- Switch pr-agent reusable workflow to `@main`

- Fix broken secret syntax from pinned SHA

- Keep `KIMI_API_KEY` secret repo-level


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".github/workflows/pr-agent.yml"] -- "uses @main" --> B["skynergroup/.github shared workflow"]
  B -- "repo-level secret" --> C["secrets.KIMI_API_KEY"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pr-agent.yml</strong><dd><code>Pin pr-agent reusable workflow to @main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/pr-agent.yml

<ul><li>Repoint reusable workflow from pinned SHA to <code>@main</code><br> <li> Retain <code>KIMI_API_KEY</code> secret at repo level<br> <li> Fix broken pr-agent workflow invocation</ul>


</details>


  </td>
  <td><a href="https://github.com/yashiels/checkers60-cli/pull/18/files#diff-69fd3473f15a98f47918e81bc4d0ca86a71131f21db13b39bebf76d27cf483b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

