### PR TITLE
P0: headless foundation (json errors, locked creds, retry, device id)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,15 @@
         "chalk": "^5.4.1",
         "cli-table3": "^0.6.5",
         "commander": "^13.1.0",
-        "ora": "^8.2.0"
+        "ora": "^8.2.0",
+        "proper-lockfile": "^4.1.2"
       },
       "bin": {
         "checkers60": "dist/cli.js"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/proper-lockfile": "^4.1.4",
         "prettier": "^3.8.4",
         "tsup": "^8.5.0",
         "tsx": "^4.19.0",
@@ -944,6 +946,23 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/proper-lockfile": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@types/proper-lockfile/-/proper-lockfile-4.1.4.tgz",
+      "integrity": "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "*"
+      }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1410,6 +1429,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1816,6 +1841,23 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1854,6 +1896,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -30,10 +30,12 @@
     "chalk": "^5.4.1",
     "cli-table3": "^0.6.5",
     "commander": "^13.1.0",
-    "ora": "^8.2.0"
+    "ora": "^8.2.0",
+    "proper-lockfile": "^4.1.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
+    "@types/proper-lockfile": "^4.1.4",
     "prettier": "^3.8.4",
     "tsup": "^8.5.0",
     "tsx": "^4.19.0",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -50,6 +50,37 @@ Use `--json` on `otp-trigger`/`otp-verify` when driving this programmatically so
 
 > The `CHECKERS60_OTP_RELAY_URL` / `CHECKERS60_OTP_RELAY_TOKEN` env vars are reserved for a future SMS-to-HTTPS relay but are **not yet wired into the CLI** — there is no auto-fetch of the OTP today. Always fall back to asking the user.
 
+## JSON output & exit codes (headless)
+
+Every command accepts `--json` for machine-readable output. You can also set it
+globally for a whole session with the `CHECKERS60_JSON` environment variable
+(any truthy value, e.g. `CHECKERS60_JSON=1`); `--json` on the command line ORs
+with it. In JSON mode all spinners and incidental log lines are suppressed, so
+stdout carries **only** the JSON payload.
+
+**Errors are JSON too.** On failure in JSON mode the CLI writes exactly one
+object to **stdout** and exits non-zero:
+
+```json
+{"error": "Authentication failed (HTTP 401).", "code": 3, "status": 401}
+```
+
+`status` is present only for server responses. The `error` string is always a
+clean summary — it never contains the raw API response body.
+
+Exit codes are stable and safe to branch on:
+
+| Code | Meaning |
+|---|---|
+| `0` | success |
+| `1` | generic runtime failure |
+| `2` | invalid usage (unknown command/option, missing argument) |
+| `3` | authentication (not logged in, HTTP 401/403) |
+| `4` | network (timeout, DNS failure, connection reset) |
+
+A `code: 3` from any command is the signal to run the OTP login flow above.
+`--help` and `--version` always print normally, even in JSON mode.
+
 ## Product commands
 
 | Command | Description |
@@ -106,4 +137,4 @@ checkers60 orders
 
 - All commands require valid credentials in `~/.openclaw/credentials/checkers60.json`. Run the OTP flow if `checkers60 status` shows an expired or missing token.
 - `otp-trigger` must only be invoked when the user explicitly asks to log in. Do not auto-trigger it in scripts or on credential errors.
-- The CLI exits non-zero on API errors and prints a human-readable error message to stderr.
+- The CLI exits non-zero on API errors. In human mode the message goes to stderr; in `--json` mode a single `{"error","code","status?"}` object goes to stdout. See the exit-code table above.

--- a/src/__tests__/api.test.ts
+++ b/src/__tests__/api.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const requestMock = vi.fn();
+vi.mock("../lib/http.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/http.js")>();
+  return { ...actual, request: (...args: unknown[]) => requestMock(...args) };
+});
+
+import { CheckersAPI } from "../lib/api.js";
+import type { TokenManager } from "../lib/credentials.js";
+import { initRuntime, resetRuntimeForTests } from "../lib/runtime.js";
+
+const origEnvDeviceId = process.env.CHECKERS60_DEVICE_ID;
+
+beforeEach(async () => {
+  process.env.CHECKERS60_DEVICE_ID = "test-device-id";
+  resetRuntimeForTests();
+  await initRuntime();
+  requestMock.mockReset();
+});
+
+afterEach(() => {
+  if (origEnvDeviceId === undefined) delete process.env.CHECKERS60_DEVICE_ID;
+  else process.env.CHECKERS60_DEVICE_ID = origEnvDeviceId;
+  resetRuntimeForTests();
+  vi.restoreAllMocks();
+});
+
+function fakeTokens(): TokenManager {
+  return { getUserToken: vi.fn().mockResolvedValue("user-tok") } as unknown as TokenManager;
+}
+
+describe("CheckersAPI.updateCart error message", () => {
+  it("throws a body-free error that never leaks the API payload", async () => {
+    // The response has no `carts`, but DOES carry a secret-looking payload that
+    // must NEVER be interpolated into the thrown error.
+    requestMock.mockResolvedValue({
+      data: { errorCode: "AUTH_DENIED", token: "leaked-secret-token" },
+    });
+
+    const api = new CheckersAPI(fakeTokens());
+    await expect(
+      api.updateCart("cart-1", [{ productId: "p", quantity: 1, price: 100 }])
+    ).rejects.toThrow(/^Cart update failed$/);
+
+    // Confirm the raw payload is absent from the message.
+    let message = "";
+    try {
+      await api.updateCart("cart-1", [{ productId: "p", quantity: 1, price: 100 }]);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBe("Cart update failed");
+    expect(message).not.toMatch(/leaked-secret-token|AUTH_DENIED|[{}]/);
+  });
+});

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { join, dirname } from "node:path";
+import { tmpdir } from "node:os";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const tsxBin = join(repoRoot, "node_modules", ".bin", "tsx");
+const entry = join(repoRoot, "src", "cli.ts");
+// A path that does not exist → the CLI is reliably "logged out".
+const NO_CREDS = join(tmpdir(), `checkers60-nonexistent-${process.pid}.json`);
+
+interface Run {
+  stdout: string;
+  stderr: string;
+  code: number;
+}
+
+function runCli(args: string[], env: Record<string, string> = {}): Promise<Run> {
+  return new Promise((resolve) => {
+    execFile(
+      tsxBin,
+      [entry, ...args],
+      {
+        env: {
+          ...process.env,
+          NO_COLOR: "1",
+          CHECKERS60_CREDS_PATH: NO_CREDS,
+          ...env,
+        },
+      },
+      (err, stdout, stderr) => {
+        const code =
+          err && typeof (err as { code?: unknown }).code === "number"
+            ? (err as { code: number }).code
+            : 0;
+        resolve({ stdout, stderr, code });
+      }
+    );
+  });
+}
+
+describe("CLI JSON mode — commander + error envelopes", () => {
+  it("status --json prints valid JSON and exits 0", async () => {
+    const r = await runCli(["status", "--json"]);
+    expect(r.code).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed).toHaveProperty("loggedIn");
+  });
+
+  it("unknown command under --json emits ONE JSON envelope with exit 2", async () => {
+    const r = await runCli(["bogus-cmd", "--json"]);
+    expect(r.code).toBe(2);
+    const parsed = JSON.parse(r.stdout.trim());
+    expect(parsed.code).toBe(2);
+    expect(typeof parsed.error).toBe("string");
+    // Buffered commander help/usage text must not leak to stdout.
+    expect(r.stdout).not.toContain("Usage:");
+    // Exactly one line of JSON output.
+    expect(r.stdout.trim().split("\n")).toHaveLength(1);
+  });
+
+  it("missing required argument under --json emits a JSON envelope with exit 2", async () => {
+    const r = await runCli(["otp-verify", "--json"]);
+    expect(r.code).toBe(2);
+    const parsed = JSON.parse(r.stdout.trim());
+    expect(parsed.code).toBe(2);
+    expect(parsed.error).toMatch(/reference/i);
+  });
+
+  it("unknown command WITHOUT --json prints human error to stderr, exit 2", async () => {
+    const r = await runCli(["bogus-cmd"]);
+    expect(r.code).toBe(2);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toContain("unknown command");
+  });
+
+  it("--help still prints normally in JSON mode and exits 0", async () => {
+    const r = await runCli(["--help", "--json"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("Usage:");
+  });
+
+  it("--version still prints normally in JSON mode and exits 0", async () => {
+    const r = await runCli(["--version", "--json"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it("CHECKERS60_JSON env enables JSON mode without the flag", async () => {
+    const r = await runCli(["status"], { CHECKERS60_JSON: "1" });
+    expect(r.code).toBe(0);
+    expect(() => JSON.parse(r.stdout)).not.toThrow();
+  });
+
+  it("an auth failure (not logged in) is a JSON envelope with exit 3", async () => {
+    const r = await runCli(["cart", "--json"]);
+    expect(r.code).toBe(3);
+    const parsed = JSON.parse(r.stdout.trim());
+    expect(parsed.code).toBe(3);
+    // No response body / secret ever appears in the error field.
+    expect(parsed.error).not.toMatch(/token|refresh/i);
+  });
+}, 30000);

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -3,6 +3,7 @@ import { execFile } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
 import { tmpdir } from "node:os";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, "..", "..");
@@ -101,5 +102,43 @@ describe("CLI JSON mode — commander + error envelopes", () => {
     expect(parsed.code).toBe(3);
     // No response body / secret ever appears in the error field.
     expect(parsed.error).not.toMatch(/token|refresh/i);
+  });
+
+  it("logout --json emits {\"cleared\":false} and NO human text when logged out", async () => {
+    // A fresh, never-created path — and logout skips initRuntime, so nothing
+    // writes a device_id here first. The file genuinely does not exist.
+    const dir = mkdtempSync(join(tmpdir(), "checkers60-loggedout-"));
+    const freshPath = join(dir, "checkers60.json");
+    try {
+      const r = await runCli(["logout", "--json"], { CHECKERS60_CREDS_PATH: freshPath });
+      expect(r.code).toBe(0);
+      expect(r.stdout.trim()).toBe('{"cleared":false}');
+      // Exactly one JSON line; no chalk/human strings leak to stdout.
+      expect(r.stdout.trim().split("\n")).toHaveLength(1);
+      expect(r.stdout).not.toMatch(/Logged out|No saved tokens/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("logout succeeds on a CORRUPT creds file (initRuntime skipped) and strips secrets", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "checkers60-logout-"));
+    const corruptPath = join(dir, "checkers60.json");
+    // Corrupt (unparseable) creds carrying a secret; also no device_id, so if
+    // initRuntime ran it would throw CredentialsCorruptError and block logout.
+    writeFileSync(corruptPath, '{ "refresh_token": "supersecret" bad json');
+    try {
+      const r = await runCli(["logout", "--json"], {
+        CHECKERS60_CREDS_PATH: corruptPath,
+      });
+      expect(r.code).toBe(0);
+      expect(r.stdout.trim()).toBe('{"cleared":true}');
+      // The secret must be gone from disk; file is valid JSON again.
+      const after = readFileSync(corruptPath, "utf8");
+      expect(after).not.toContain("supersecret");
+      expect(() => JSON.parse(after)).not.toThrow();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 }, 30000);

--- a/src/__tests__/creds-store.test.ts
+++ b/src/__tests__/creds-store.test.ts
@@ -19,7 +19,6 @@ import { TokenManager, clearCredentials } from "../lib/credentials.js";
 import { initRuntime, resetRuntimeForTests } from "../lib/runtime.js";
 import {
   atomicWriteJson,
-  sweepOrphans,
   withCredentialsLock,
   updateBffToken,
   readCredentials,
@@ -96,7 +95,7 @@ describe("atomicWriteJson", () => {
   });
 });
 
-describe("sweepOrphans", () => {
+describe("orphan sweep (via withCredentialsLock)", () => {
   it("removes 0600 crash orphans matching the pattern, leaving other writers' temps", async () => {
     // A crash orphan for THIS store — created via the same 0600 mechanism.
     const orphan = join(tempDir, `.${basename(credsPath)}.tmp.99999.deadbeef`);
@@ -107,7 +106,9 @@ describe("sweepOrphans", () => {
     const otherLive = join(tempDir, ".other.json.tmp.1.abcdef");
     closeSync(openSync(otherLive, "wx", 0o600));
 
-    await sweepOrphans(credsPath);
+    // The sweep is only reachable while the lock is held; a no-op transaction
+    // triggers it before any temp of ours exists.
+    await withCredentialsLock(async () => undefined);
 
     expect(existsSync(orphan)).toBe(false);
     expect(existsSync(otherLive)).toBe(true);
@@ -184,6 +185,32 @@ describe("logout", () => {
     expect(disk.mobile).toBeUndefined();
     expect(disk.sixty60_user_id).toBeUndefined();
     expect(mode(credsPath)).toBe(0o600);
+  });
+
+  it("clears a CORRUPT file so no secrets remain, and reports cleared=true", async () => {
+    // A corrupt file that still holds a secret on disk. It parses to nothing,
+    // but logout MUST still overwrite it — never leave the secret behind.
+    writeFileSync(
+      credsPath,
+      '{ "device_id": "dev-xyz", "refresh_token": "secret-refresh" } trailing garbage'
+    );
+    const cleared = await clearCredentials();
+    // File existed, so logout reports cleared=true even though it was unparseable.
+    expect(cleared).toBe(true);
+    // No secret bytes survive anywhere in the file.
+    const raw = readFileSync(credsPath, "utf8");
+    expect(raw).not.toContain("secret-refresh");
+    // File is valid JSON again with no token/identity fields.
+    const disk = readDisk();
+    expect(disk.refresh_token).toBeUndefined();
+    expect(disk.user_token).toBeUndefined();
+    expect(mode(credsPath)).toBe(0o600);
+  });
+
+  it("returns false when no creds file exists", async () => {
+    rmSync(credsPath, { force: true });
+    const cleared = await clearCredentials();
+    expect(cleared).toBe(false);
   });
 });
 

--- a/src/__tests__/creds-store.test.ts
+++ b/src/__tests__/creds-store.test.ts
@@ -1,0 +1,323 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  statSync,
+  existsSync,
+  openSync,
+  closeSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, basename } from "node:path";
+import { CONFIG } from "../lib/config.js";
+import { TokenManager, clearCredentials } from "../lib/credentials.js";
+import {
+  atomicWriteJson,
+  sweepOrphans,
+  withCredentialsLock,
+  updateBffToken,
+  readCredentials,
+  CredentialsCorruptError,
+  TransactionAbortedError,
+  type CredentialsFile,
+} from "../lib/creds-store.js";
+
+let tempDir: string;
+let credsPath: string;
+const origCredsPath = CONFIG.CREDS_PATH;
+const realFetch = globalThis.fetch;
+
+function readDisk(): CredentialsFile {
+  return JSON.parse(readFileSync(credsPath, "utf8")) as CredentialsFile;
+}
+
+function seed(creds: CredentialsFile): void {
+  writeFileSync(credsPath, JSON.stringify(creds, null, 2));
+}
+
+function mode(path: string): number {
+  return statSync(path).mode & 0o777;
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "creds-test-"));
+  credsPath = join(tempDir, "checkers60.json");
+  CONFIG.CREDS_PATH = credsPath;
+});
+
+afterEach(() => {
+  CONFIG.CREDS_PATH = origCredsPath;
+  globalThis.fetch = realFetch;
+  vi.restoreAllMocks();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("atomicWriteJson", () => {
+  it("writes the file with mode 0600 and creates the dir 0700", async () => {
+    const nested = join(tempDir, "sub", "checkers60.json");
+    CONFIG.CREDS_PATH = nested;
+    await atomicWriteJson(nested, { bff_token: "x" });
+    expect(mode(nested)).toBe(0o600);
+    expect(mode(dirname(nested))).toBe(0o700);
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it("leaves no temp files behind after a successful write", async () => {
+    await atomicWriteJson(credsPath, { bff_token: "x" });
+    const temps = readdirSync(tempDir).filter((f) => f.includes(".tmp."));
+    expect(temps).toHaveLength(0);
+  });
+
+  it("cleans up the temp and does not commit when the gate throws", async () => {
+    seed({ user_token: "keep" });
+    await expect(
+      atomicWriteJson(credsPath, { user_token: "new" }, () => {
+        throw new Error("gate blocked");
+      })
+    ).rejects.toThrow("gate blocked");
+    expect(readDisk().user_token).toBe("keep");
+    const temps = readdirSync(tempDir).filter((f) => f.includes(".tmp."));
+    expect(temps).toHaveLength(0);
+  });
+});
+
+describe("sweepOrphans", () => {
+  it("removes 0600 crash orphans matching the pattern, leaving other writers' temps", async () => {
+    // A crash orphan for THIS store — created via the same 0600 mechanism.
+    const orphan = join(tempDir, `.${basename(credsPath)}.tmp.99999.deadbeef`);
+    closeSync(openSync(orphan, "wx", 0o600));
+    expect(mode(orphan)).toBe(0o600);
+
+    // Another writer's live temp (different basename) must be untouched.
+    const otherLive = join(tempDir, ".other.json.tmp.1.abcdef");
+    closeSync(openSync(otherLive, "wx", 0o600));
+
+    await sweepOrphans(credsPath);
+
+    expect(existsSync(orphan)).toBe(false);
+    expect(existsSync(otherLive)).toBe(true);
+  });
+});
+
+describe("field-scoped updaters", () => {
+  it("updateBffToken never clobbers user tokens (stale-overwrite scenario)", async () => {
+    seed({
+      user_token: "user-a",
+      refresh_token: "refresh-a",
+      user_expiry: Date.now() + 3_600_000,
+    });
+    await updateBffToken({ bffToken: "bff-new", bffExpiry: Date.now() + 86_400_000 });
+    const disk = readDisk();
+    expect(disk.bff_token).toBe("bff-new");
+    expect(disk.user_token).toBe("user-a");
+    expect(disk.refresh_token).toBe("refresh-a");
+    expect(mode(credsPath)).toBe(0o600);
+  });
+});
+
+describe("corruption safety", () => {
+  it("throws (does not silently overwrite) on a corrupt file in a write transaction", async () => {
+    writeFileSync(credsPath, "{ not json ]");
+    await expect(
+      updateBffToken({ bffToken: "bff", bffExpiry: 1 })
+    ).rejects.toBeInstanceOf(CredentialsCorruptError);
+    // File must be left untouched, not overwritten.
+    expect(readFileSync(credsPath, "utf8")).toBe("{ not json ]");
+  });
+
+  it("readCredentials degrades to {} in lenient mode", async () => {
+    writeFileSync(credsPath, "{ not json ]");
+    await expect(readCredentials(credsPath, true)).resolves.toEqual({});
+  });
+});
+
+describe("commit gate / transaction deadline", () => {
+  it("rejects a write once the deadline has passed, without committing", async () => {
+    seed({ user_token: "keep" });
+    await expect(
+      withCredentialsLock(
+        async (ctx) => {
+          await new Promise((r) => setTimeout(r, 60));
+          return ctx.writePatch({ user_token: "too-late" });
+        },
+        { deadlineMs: 10 }
+      )
+    ).rejects.toBeInstanceOf(TransactionAbortedError);
+    expect(readDisk().user_token).toBe("keep");
+  });
+});
+
+describe("logout", () => {
+  it("preserves device_id and drops all token/identity fields", async () => {
+    seed({
+      device_id: "dev-123",
+      user_token: "u",
+      refresh_token: "r",
+      user_expiry: Date.now() + 1000,
+      bff_token: "b",
+      mobile: "+27000",
+      customer_id: "cust",
+      sixty60_user_id: "s60",
+    });
+    const cleared = await clearCredentials();
+    expect(cleared).toBe(true);
+    const disk = readDisk();
+    expect(disk.device_id).toBe("dev-123");
+    expect(disk.user_token).toBeUndefined();
+    expect(disk.refresh_token).toBeUndefined();
+    expect(disk.bff_token).toBeUndefined();
+    expect(disk.mobile).toBeUndefined();
+    expect(disk.sixty60_user_id).toBeUndefined();
+    expect(mode(credsPath)).toBe(0o600);
+  });
+});
+
+describe("TokenManager.getUserToken reconciliation", () => {
+  it("adopts a still-valid identical disk token with NO network refresh", async () => {
+    seed({
+      user_token: "valid-token",
+      refresh_token: "refresh-a",
+      user_expiry: Date.now() + 3_600_000,
+    });
+    const fetchMock = vi.fn(() => {
+      throw new Error("network must not be called");
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const tm = new TokenManager();
+    await expect(tm.getUserToken()).resolves.toBe("valid-token");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("throws logged-out when disk has no refresh token (never resurrects memory)", async () => {
+    seed({ user_token: "stale", user_expiry: 0 });
+    const tm = new TokenManager();
+    // Simulate a stale in-memory refresh token that must NOT be resurrected.
+    tm.refreshToken = "ghost-refresh";
+    await expect(tm.getUserToken()).rejects.toThrow(/Not logged in/);
+  });
+
+  it("keeps the old refresh token when the refresh response omits a new one", async () => {
+    seed({
+      user_token: "expired",
+      refresh_token: "refresh-old",
+      user_expiry: 0,
+    });
+    const fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/token/dsl")) {
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "bff", expires_in: 86_400 }), {
+            status: 200,
+          })
+        );
+      }
+      // Refresh response WITHOUT a refreshToken.
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({ response: { accessToken: "user-new", expiresIn: 3600 } }),
+          { status: 200 }
+        )
+      );
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const tm = new TokenManager();
+    await expect(tm.getUserToken()).resolves.toBe("user-new");
+    const disk = readDisk();
+    expect(disk.refresh_token).toBe("refresh-old");
+    expect(disk.user_token).toBe("user-new");
+  });
+
+  it("nested getUserToken -> getBFFTokenLocked does not deadlock", async () => {
+    seed({
+      user_token: "expired",
+      refresh_token: "refresh-old",
+      user_expiry: 0,
+      // No bff token → forces the in-lock getBFFTokenLocked network path.
+    });
+    let bffCalls = 0;
+    globalThis.fetch = ((input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/token/dsl")) {
+        bffCalls += 1;
+        return Promise.resolve(
+          new Response(JSON.stringify({ access_token: "bff", expires_in: 86_400 }), {
+            status: 200,
+          })
+        );
+      }
+      return Promise.resolve(
+        new Response(
+          JSON.stringify({
+            response: { accessToken: "user-new", refreshToken: "refresh-new", expiresIn: 3600 },
+          }),
+          { status: 200 }
+        )
+      );
+    }) as unknown as typeof fetch;
+
+    const tm = new TokenManager();
+    // If the nested lock deadlocked this would hang; the test timeout guards it.
+    const token = await tm.getUserToken();
+    expect(token).toBe("user-new");
+    expect(bffCalls).toBe(1);
+    expect(readDisk().bff_token).toBe("bff");
+  }, 5000);
+});
+
+describe("cross-process locking (real child processes)", () => {
+  it("two concurrent refreshers => exactly ONE network refresh, both converge", async () => {
+    seed({
+      user_token: "expired",
+      refresh_token: "refresh-old",
+      user_expiry: 0,
+    });
+    const counterPath = join(tempDir, "refresh-count");
+    writeFileSync(counterPath, "");
+    const workerPath = fileURLToPath(new URL("./refresh-worker.ts", import.meta.url));
+    const barrier = Date.now() + 400;
+
+    const run = (): Promise<{ code: number; out: string; err: string }> =>
+      new Promise((resolve) => {
+        const child = spawn(process.execPath, ["--import", "tsx", workerPath], {
+          env: {
+            ...process.env,
+            CHECKERS60_CREDS_PATH: credsPath,
+            WORKER_COUNTER: counterPath,
+            BARRIER_TS: String(barrier),
+          },
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let out = "";
+        let err = "";
+        child.stdout.on("data", (d) => (out += d));
+        child.stderr.on("data", (d) => (err += d));
+        child.on("close", (code) => resolve({ code: code ?? 0, out, err }));
+      });
+
+    const [a, b] = await Promise.all([run(), run()]);
+
+    expect(a.code, `worker A failed: ${a.err}`).toBe(0);
+    expect(b.code, `worker B failed: ${b.err}`).toBe(0);
+
+    const refreshCount = readFileSync(counterPath, "utf8").length;
+    expect(refreshCount).toBe(1);
+
+    const disk = readDisk();
+    expect(disk.user_token).toBe("user-new");
+    expect(disk.refresh_token).toBe("refresh-new");
+
+    const resA = JSON.parse(a.out.trim());
+    const resB = JSON.parse(b.out.trim());
+    expect(resA.token).toBe("user-new");
+    expect(resB.token).toBe("user-new");
+    expect(resA.refreshToken).toBe("refresh-new");
+    expect(resB.refreshToken).toBe("refresh-new");
+  }, 20_000);
+});

--- a/src/__tests__/creds-store.test.ts
+++ b/src/__tests__/creds-store.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { CONFIG } from "../lib/config.js";
 import { TokenManager, clearCredentials } from "../lib/credentials.js";
+import { initRuntime, resetRuntimeForTests } from "../lib/runtime.js";
 import {
   atomicWriteJson,
   sweepOrphans,
@@ -30,6 +31,7 @@ import {
 let tempDir: string;
 let credsPath: string;
 const origCredsPath = CONFIG.CREDS_PATH;
+const origEnvDeviceId = process.env.CHECKERS60_DEVICE_ID;
 const realFetch = globalThis.fetch;
 
 function readDisk(): CredentialsFile {
@@ -44,14 +46,22 @@ function mode(path: string): number {
   return statSync(path).mode & 0o777;
 }
 
-beforeEach(() => {
+beforeEach(async () => {
   tempDir = mkdtempSync(join(tmpdir(), "creds-test-"));
   credsPath = join(tempDir, "checkers60.json");
   CONFIG.CREDS_PATH = credsPath;
+  // Header builders read the resolved device id via getDeviceId(); pin one via
+  // env (session-only, never persisted) so this suite's token flows can run.
+  process.env.CHECKERS60_DEVICE_ID = "test-device-id";
+  resetRuntimeForTests();
+  await initRuntime();
 });
 
 afterEach(() => {
   CONFIG.CREDS_PATH = origCredsPath;
+  if (origEnvDeviceId === undefined) delete process.env.CHECKERS60_DEVICE_ID;
+  else process.env.CHECKERS60_DEVICE_ID = origEnvDeviceId;
+  resetRuntimeForTests();
   globalThis.fetch = realFetch;
   vi.restoreAllMocks();
   rmSync(tempDir, { recursive: true, force: true });
@@ -289,6 +299,7 @@ describe("cross-process locking (real child processes)", () => {
           env: {
             ...process.env,
             CHECKERS60_CREDS_PATH: credsPath,
+            CHECKERS60_DEVICE_ID: "test-device-id",
             WORKER_COUNTER: counterPath,
             BARRIER_TS: String(barrier),
           },

--- a/src/__tests__/device-worker.ts
+++ b/src/__tests__/device-worker.ts
@@ -1,0 +1,26 @@
+/**
+ * Child-process worker for the cross-process device-id convergence test.
+ * Spawned with `node --import tsx`. With no `CHECKERS60_DEVICE_ID` env and no
+ * persisted `device_id`, two of these racing on the same creds file must
+ * converge to ONE generated id (generation is serialized by the credential
+ * lock). Prints the resolved id as JSON.
+ *
+ * Env: CHECKERS60_CREDS_PATH (shared creds file), BARRIER_TS (ms epoch to start
+ * together). CHECKERS60_DEVICE_ID must be UNSET.
+ */
+import { resolveDeviceId } from "../lib/runtime.js";
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+async function main(): Promise<void> {
+  const barrier = Number(process.env.BARRIER_TS ?? 0);
+  while (Date.now() < barrier) await sleep(5);
+
+  const deviceId = await resolveDeviceId();
+  process.stdout.write(`${JSON.stringify({ deviceId })}\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/__tests__/errors.test.ts
+++ b/src/__tests__/errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyError,
+  UsageError,
+  EXIT_FAILURE,
+  EXIT_USAGE,
+  EXIT_AUTH,
+  EXIT_NETWORK,
+} from "../lib/errors.js";
+import { APIError } from "../lib/api.js";
+
+const SECRET_BODY =
+  '{"refresh_token":"super-secret-xyz","message":"internal detail leaked"}';
+
+describe("classifyError — exit code mapping", () => {
+  it("maps UsageError to exit 2", () => {
+    const c = classifyError(new UsageError("bad flag"));
+    expect(c.code).toBe(EXIT_USAGE);
+    expect(c.message).toBe("bad flag");
+  });
+
+  it("maps 401/403 API errors to exit 3 (auth) with status", () => {
+    for (const status of [401, 403]) {
+      const c = classifyError(new APIError(status, "Unauthorized", SECRET_BODY, "/x"));
+      expect(c.code).toBe(EXIT_AUTH);
+      expect(c.status).toBe(status);
+    }
+  });
+
+  it("maps other API errors to exit 1 (generic) with status", () => {
+    const c = classifyError(new APIError(500, "Server Error", SECRET_BODY, "/orders"));
+    expect(c.code).toBe(EXIT_FAILURE);
+    expect(c.status).toBe(500);
+  });
+
+  it("maps 'Not logged in' to exit 3 (auth)", () => {
+    const c = classifyError(new Error("Not logged in. Run checkers60 login."));
+    expect(c.code).toBe(EXIT_AUTH);
+  });
+
+  it.each([
+    ["fetch failed", new Error("fetch failed")],
+    ["timeout/abort", Object.assign(new Error("aborted"), { name: "AbortError" })],
+    ["ECONNREFUSED", Object.assign(new Error("connect"), { code: "ECONNREFUSED" })],
+    ["ENOTFOUND", Object.assign(new Error("dns"), { code: "ENOTFOUND" })],
+    ["ETIMEDOUT", Object.assign(new Error("slow"), { code: "ETIMEDOUT" })],
+  ])("maps network failure (%s) to exit 4", (_label, err) => {
+    expect(classifyError(err).code).toBe(EXIT_NETWORK);
+  });
+
+  it("maps a plain runtime error to exit 1", () => {
+    expect(classifyError(new Error("boom")).code).toBe(EXIT_FAILURE);
+  });
+
+  it("maps a non-Error throw to exit 1", () => {
+    expect(classifyError("weird").code).toBe(EXIT_FAILURE);
+  });
+});
+
+describe("classifyError — never leaks the response body", () => {
+  it("excludes APIError.body from the user-facing message (all statuses)", () => {
+    for (const status of [401, 403, 429, 500, 502]) {
+      const c = classifyError(new APIError(status, "X", SECRET_BODY, "/secret"));
+      expect(c.message).not.toContain("super-secret-xyz");
+      expect(c.message).not.toContain("internal detail leaked");
+    }
+  });
+
+  it("keeps any verbose status line body-free and query-free", () => {
+    const c = classifyError(new APIError(500, "X", SECRET_BODY, "/tokens"));
+    if (c.verboseLine) {
+      expect(c.verboseLine).not.toContain("super-secret-xyz");
+      expect(c.verboseLine).not.toContain("?");
+    }
+  });
+});

--- a/src/__tests__/http.test.ts
+++ b/src/__tests__/http.test.ts
@@ -5,6 +5,8 @@ import {
   TimeoutError,
   ExternalAbortError,
   redactUrl,
+  parseRetryAfter,
+  MAX_ATTEMPTS,
 } from "../lib/http.js";
 
 function abortError(): Error {
@@ -37,15 +39,29 @@ function abortAwareFetch(bodyNeverResolves = false) {
 
 function fakeResponse(
   body: unknown,
-  { status = 200, statusText = "OK" }: { status?: number; statusText?: string } = {}
+  {
+    status = 200,
+    statusText = "OK",
+    headers = {},
+  }: { status?: number; statusText?: string; headers?: Record<string, string> } = {}
 ): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
     statusText,
-    headers: new Headers(),
+    headers: new Headers(headers),
     text: async () => (typeof body === "string" ? body : JSON.stringify(body)),
   } as unknown as Response;
+}
+
+/** fetch mock that returns/throws one step per call, repeating the last step. */
+function stepFetch(steps: Array<Response | Error>) {
+  let i = 0;
+  return vi.fn((): Promise<Response> => {
+    const step = steps[Math.min(i, steps.length - 1)];
+    i++;
+    return step instanceof Error ? Promise.reject(step) : Promise.resolve(step);
+  });
 }
 
 interface FetchInit {
@@ -227,5 +243,151 @@ describe("request cleanup", () => {
 
     expect(clearSpy).toHaveBeenCalled();
     expect(removeSpy).toHaveBeenCalled();
+  });
+});
+
+describe("parseRetryAfter", () => {
+  it("parses the delta-seconds form and converts to ms", () => {
+    expect(parseRetryAfter("2", 60_000)).toBe(2000);
+  });
+
+  it("parses the HTTP-date form relative to now", () => {
+    const when = new Date(Date.now() + 3000).toUTCString();
+    const ms = parseRetryAfter(when, 60_000);
+    expect(ms).toBeGreaterThan(1000);
+    expect(ms).toBeLessThanOrEqual(3000);
+  });
+
+  it("caps the parsed delay at capMs", () => {
+    expect(parseRetryAfter("3600", 5000)).toBe(5000);
+    const farFuture = new Date(Date.now() + 3_600_000).toUTCString();
+    expect(parseRetryAfter(farFuture, 5000)).toBe(5000);
+  });
+
+  it("returns undefined for an absent or unparseable value", () => {
+    expect(parseRetryAfter(undefined, 60_000)).toBeUndefined();
+    expect(parseRetryAfter("not-a-date", 60_000)).toBeUndefined();
+  });
+});
+
+describe("request retry policy", () => {
+  const fast = { retry: "safe" as const, backoffBaseMs: 1, backoffCapMs: 2 };
+
+  it("retries a 503 then succeeds (safe)", async () => {
+    const fetchMock = stepFetch([
+      fakeResponse("busy", { status: 503, statusText: "Service Unavailable" }),
+      fakeResponse({ ok: true }),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request<{ ok: boolean }>("GET", "https://example.com/x", fast);
+    expect(res.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a pre-response network error then succeeds (safe)", async () => {
+    const fetchMock = stepFetch([new TypeError("network down"), fakeResponse({ ok: true })]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request<{ ok: boolean }>("GET", "https://example.com/x", fast);
+    expect(res.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry a 400 (non-retryable status)", async () => {
+    const fetchMock = stepFetch([fakeResponse("bad", { status: 400 })]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(request("GET", "https://example.com/x", fast)).rejects.toBeInstanceOf(APIError);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry a mutation / retry:\"never\" call at all", async () => {
+    const fetchMock = stepFetch([fakeResponse("busy", { status: 503 })]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Default policy is "never".
+    await expect(request("POST", "https://example.com/cart", { json: {} })).rejects.toBeInstanceOf(
+      APIError
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("never retries an external abort and never relabels it as a timeout", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch());
+    const ext = new AbortController();
+    const p = request("GET", "https://example.com/x", {
+      ...fast,
+      signal: ext.signal,
+      timeoutMs: 10_000,
+    });
+    ext.abort();
+
+    const err = await p.catch((e) => e);
+    expect(err).toBeInstanceOf(ExternalAbortError);
+    expect(err).not.toBeInstanceOf(TimeoutError);
+    expect((globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length).toBe(1);
+  });
+
+  it("honors and caps a Retry-After header (seconds form)", async () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+    const fetchMock = stepFetch([
+      fakeResponse("busy", { status: 503, headers: { "retry-after": "3600" } }),
+      fakeResponse({ ok: true }),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request<{ ok: boolean }>("GET", "https://example.com/x", {
+      retry: "safe",
+      retryAfterCapMs: 40,
+    });
+    expect(res.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // The backoff wait is the capped Retry-After (40ms), never the raw 3600s.
+    const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+    expect(delays).toContain(40);
+    expect(delays.every((d) => (d ?? 0) < 3_600_000)).toBe(true);
+  });
+
+  it("honors a Retry-After header in HTTP-date form", async () => {
+    const when = new Date(Date.now() + 20).toUTCString();
+    const fetchMock = stepFetch([
+      fakeResponse("busy", { status: 503, headers: { "retry-after": when } }),
+      fakeResponse({ ok: true }),
+    ]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const res = await request<{ ok: boolean }>("GET", "https://example.com/x", {
+      retry: "safe",
+      retryAfterCapMs: 60_000,
+    });
+    expect(res.data.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds total retrying by the overall time budget", async () => {
+    // Budget is too small to afford even a second attempt's backoff.
+    const fetchMock = stepFetch([fakeResponse("busy", { status: 503 })]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      request("GET", "https://example.com/x", {
+        retry: "safe",
+        retryBudgetMs: 5,
+        backoffBaseMs: 1000,
+      })
+    ).rejects.toBeInstanceOf(APIError);
+    // Fewer than the max attempts because the budget ran out.
+    expect(fetchMock.mock.calls.length).toBeLessThan(MAX_ATTEMPTS);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects the max-3-attempts ceiling", async () => {
+    const fetchMock = stepFetch([fakeResponse("busy", { status: 503 })]);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(request("GET", "https://example.com/x", fast)).rejects.toBeInstanceOf(APIError);
+    expect(fetchMock).toHaveBeenCalledTimes(MAX_ATTEMPTS);
+    expect(MAX_ATTEMPTS).toBe(3);
   });
 });

--- a/src/__tests__/http.test.ts
+++ b/src/__tests__/http.test.ts
@@ -1,5 +1,39 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { request, APIError } from "../lib/http.js";
+import {
+  request,
+  APIError,
+  TimeoutError,
+  ExternalAbortError,
+  redactUrl,
+} from "../lib/http.js";
+
+function abortError(): Error {
+  const e = new Error("The operation was aborted.");
+  e.name = "AbortError";
+  return e;
+}
+
+/** fetch mock that rejects with an AbortError once its (internal) signal aborts. */
+function abortAwareFetch(bodyNeverResolves = false) {
+  return vi.fn((_url: string, init: { signal: AbortSignal }): Promise<Response> => {
+    if (init.signal.aborted) return Promise.reject(abortError());
+    if (bodyNeverResolves) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        headers: new Headers(),
+        text: () =>
+          new Promise<string>((_resolve, reject) => {
+            init.signal.addEventListener("abort", () => reject(abortError()));
+          }),
+      } as unknown as Response);
+    }
+    return new Promise<Response>((_resolve, reject) => {
+      init.signal.addEventListener("abort", () => reject(abortError()));
+    });
+  });
+}
 
 function fakeResponse(
   body: unknown,
@@ -29,6 +63,7 @@ function makeFetchMock() {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.restoreAllMocks();
 });
 
 describe("request body encoding", () => {
@@ -78,5 +113,119 @@ describe("request response handling", () => {
   it("throws APIError on non-2xx responses", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => fakeResponse("nope", { status: 500 })));
     await expect(request("GET", "https://example.com/boom")).rejects.toBeInstanceOf(APIError);
+  });
+});
+
+describe("redactUrl", () => {
+  it("keeps origin+pathname and drops the query string", () => {
+    expect(redactUrl("https://example.com/tokens?refreshToken=SECRET&x=1")).toBe(
+      "https://example.com/tokens"
+    );
+  });
+
+  it("keeps a bare origin+pathname unchanged", () => {
+    expect(redactUrl("https://example.com/a/b")).toBe("https://example.com/a/b");
+  });
+});
+
+describe("request abort + timeout", () => {
+  it("rejects with an external-abort error, distinct from a timeout", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch());
+    const ext = new AbortController();
+    const p = request("GET", "https://example.com/x", {
+      signal: ext.signal,
+      timeoutMs: 10_000,
+    });
+    ext.abort();
+
+    const err = await p.catch((e) => e);
+    expect(err).toBeInstanceOf(ExternalAbortError);
+    expect(err).not.toBeInstanceOf(TimeoutError);
+    expect(err.external).toBe(true);
+    expect(err.name).toBe("AbortError");
+  });
+
+  it("rejects immediately when the external signal is already aborted", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch());
+    const ext = new AbortController();
+    ext.abort();
+    const err = await request("GET", "https://example.com/x", { signal: ext.signal }).catch(
+      (e) => e
+    );
+    expect(err).toBeInstanceOf(ExternalAbortError);
+  });
+
+  it("times out a hanging body read (resp.text never resolves)", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch(true));
+    const err = await request("GET", "https://example.com/slow", { timeoutMs: 20 }).catch(
+      (e) => e
+    );
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect(err.external).toBeUndefined();
+  });
+
+  it("times out a hanging fetch, distinct from an external abort", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch());
+    const err = await request("GET", "https://example.com/slow", { timeoutMs: 20 }).catch(
+      (e) => e
+    );
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect(err).not.toBeInstanceOf(ExternalAbortError);
+  });
+});
+
+describe("request error redaction", () => {
+  const secretUrl = "https://example.com/tokens?refreshToken=SECRET123&foo=bar";
+
+  it("keeps the refresh token out of timeout messages", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch());
+    const err = await request("GET", secretUrl, { timeoutMs: 20 }).catch((e) => e);
+    expect(err).toBeInstanceOf(TimeoutError);
+    expect(err.message).toContain("https://example.com/tokens");
+    expect(err.message).not.toContain("SECRET123");
+    expect(err.message).not.toContain("refreshToken");
+    expect(err.message).not.toContain("?");
+  });
+
+  it("keeps the refresh token out of external-abort messages", async () => {
+    vi.stubGlobal("fetch", abortAwareFetch());
+    const ext = new AbortController();
+    const p = request("GET", secretUrl, { signal: ext.signal, timeoutMs: 10_000 });
+    ext.abort();
+    const err = await p.catch((e) => e);
+    expect(err).toBeInstanceOf(ExternalAbortError);
+    expect(err.message).not.toContain("SECRET123");
+    expect(err.message).not.toContain("refreshToken");
+    expect(err.message).not.toContain("?");
+  });
+});
+
+describe("request cleanup", () => {
+  it("clears the timer and removes the external listener on success", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    vi.stubGlobal("fetch", vi.fn(async () => fakeResponse({ ok: true })));
+    const ext = new AbortController();
+    const removeSpy = vi.spyOn(ext.signal, "removeEventListener");
+
+    await request("GET", "https://example.com/x", { signal: ext.signal });
+
+    expect(clearSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
+    // Listener is gone: aborting after completion is inert.
+    expect(() => ext.abort()).not.toThrow();
+  });
+
+  it("clears the timer and removes the external listener on the APIError path", async () => {
+    const clearSpy = vi.spyOn(globalThis, "clearTimeout");
+    vi.stubGlobal("fetch", vi.fn(async () => fakeResponse("nope", { status: 500 })));
+    const ext = new AbortController();
+    const removeSpy = vi.spyOn(ext.signal, "removeEventListener");
+
+    await expect(
+      request("GET", "https://example.com/boom", { signal: ext.signal })
+    ).rejects.toBeInstanceOf(APIError);
+
+    expect(clearSpy).toHaveBeenCalled();
+    expect(removeSpy).toHaveBeenCalled();
   });
 });

--- a/src/__tests__/refresh-worker.ts
+++ b/src/__tests__/refresh-worker.ts
@@ -1,0 +1,58 @@
+/**
+ * Child-process worker for the cross-process credential-lock test. Spawned with
+ * `node --import tsx`. It mocks the network at the global `fetch` boundary,
+ * counts each real token-refresh call by appending to WORKER_COUNTER, then runs
+ * the real `TokenManager.getUserToken()` reconciliation under the file lock.
+ *
+ * Env: CHECKERS60_CREDS_PATH (shared creds file), WORKER_COUNTER (refresh tally
+ * file), BARRIER_TS (ms epoch to start together).
+ */
+import { appendFileSync } from "node:fs";
+import { TokenManager } from "../lib/credentials.js";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    statusText: "OK",
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const counterPath = process.env.WORKER_COUNTER as string;
+
+globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
+  const url = String(input);
+  if (url.includes("/token/dsl")) {
+    return jsonResponse({ access_token: "bff-token", expires_in: 86_400 });
+  }
+  if (url.includes("/tokens?refreshToken=")) {
+    // Count a real network refresh and widen the contention window.
+    appendFileSync(counterPath, "x");
+    await sleep(200);
+    return jsonResponse({
+      response: {
+        accessToken: "user-new",
+        refreshToken: "refresh-new",
+        expiresIn: 3600,
+      },
+    });
+  }
+  throw new Error(`unexpected fetch: ${url}`);
+}) as typeof fetch;
+
+async function main(): Promise<void> {
+  const barrier = Number(process.env.BARRIER_TS ?? 0);
+  while (Date.now() < barrier) await sleep(5);
+
+  const tm = new TokenManager();
+  const token = await tm.getUserToken();
+  process.stdout.write(
+    `${JSON.stringify({ token, userToken: tm.userToken, refreshToken: tm.refreshToken })}\n`
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`${err instanceof Error ? err.stack : String(err)}\n`);
+  process.exit(1);
+});

--- a/src/__tests__/refresh-worker.ts
+++ b/src/__tests__/refresh-worker.ts
@@ -9,6 +9,7 @@
  */
 import { appendFileSync } from "node:fs";
 import { TokenManager } from "../lib/credentials.js";
+import { initRuntime } from "../lib/runtime.js";
 
 function jsonResponse(body: unknown): Response {
   return new Response(JSON.stringify(body), {
@@ -42,6 +43,7 @@ globalThis.fetch = (async (input: RequestInfo | URL): Promise<Response> => {
 }) as typeof fetch;
 
 async function main(): Promise<void> {
+  await initRuntime();
   const barrier = Number(process.env.BARRIER_TS ?? 0);
   while (Date.now() < barrier) await sleep(5);
 

--- a/src/__tests__/runtime.test.ts
+++ b/src/__tests__/runtime.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import {
+  mkdtempSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CONFIG } from "../lib/config.js";
+import {
+  resolveDeviceId,
+  initRuntime,
+  getDeviceId,
+  resetRuntimeForTests,
+} from "../lib/runtime.js";
+import { TokenManager, clearCredentials } from "../lib/credentials.js";
+import { type CredentialsFile } from "../lib/creds-store.js";
+
+let tempDir: string;
+let credsPath: string;
+const origCredsPath = CONFIG.CREDS_PATH;
+const origEnvDeviceId = process.env.CHECKERS60_DEVICE_ID;
+
+function readDisk(): CredentialsFile {
+  return JSON.parse(readFileSync(credsPath, "utf8")) as CredentialsFile;
+}
+
+function seed(creds: CredentialsFile): void {
+  writeFileSync(credsPath, JSON.stringify(creds, null, 2));
+}
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "runtime-test-"));
+  credsPath = join(tempDir, "checkers60.json");
+  CONFIG.CREDS_PATH = credsPath;
+  delete process.env.CHECKERS60_DEVICE_ID;
+  resetRuntimeForTests();
+});
+
+afterEach(() => {
+  CONFIG.CREDS_PATH = origCredsPath;
+  if (origEnvDeviceId === undefined) delete process.env.CHECKERS60_DEVICE_ID;
+  else process.env.CHECKERS60_DEVICE_ID = origEnvDeviceId;
+  resetRuntimeForTests();
+  rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("resolveDeviceId precedence", () => {
+  it("uses CHECKERS60_DEVICE_ID env and does NOT persist it (no creds file created)", async () => {
+    process.env.CHECKERS60_DEVICE_ID = "env-fixed-id";
+    await expect(resolveDeviceId()).resolves.toBe("env-fixed-id");
+    expect(existsSync(credsPath)).toBe(false);
+  });
+
+  it("env override does NOT overwrite an already-persisted device_id", async () => {
+    seed({ device_id: "persisted-id", user_token: "u" });
+    process.env.CHECKERS60_DEVICE_ID = "env-fixed-id";
+    await expect(resolveDeviceId()).resolves.toBe("env-fixed-id");
+    expect(readDisk().device_id).toBe("persisted-id");
+  });
+
+  it("adopts a persisted device_id without generating a new one", async () => {
+    seed({ device_id: "disk-id" });
+    await expect(resolveDeviceId()).resolves.toBe("disk-id");
+    expect(readDisk().device_id).toBe("disk-id");
+  });
+
+  it("first run with no env + no persisted id generates, persists, and is STABLE", async () => {
+    const first = await resolveDeviceId();
+    expect(first).toMatch(/^[0-9a-f]{16}$/);
+    expect(readDisk().device_id).toBe(first);
+    // A second resolution reads the same persisted id (no rotation).
+    const second = await resolveDeviceId();
+    expect(second).toBe(first);
+  });
+});
+
+describe("initRuntime + getDeviceId", () => {
+  it("getDeviceId throws (fail-fast) before initRuntime resolves it", () => {
+    expect(() => getDeviceId()).toThrow(/Runtime not initialized/);
+  });
+
+  it("a header builder used before initRuntime throws (fail-fast)", () => {
+    const tm = new TokenManager();
+    expect(() => tm.shopriteHeaders("bff-token")).toThrow(/Runtime not initialized/);
+  });
+
+  it("after initRuntime, getDeviceId returns the resolved id and header builders use it", async () => {
+    const id = await initRuntime();
+    expect(getDeviceId()).toBe(id);
+    const headers = new TokenManager().shopriteHeaders("bff-token");
+    expect(headers["device-id"]).toBe(id);
+  });
+
+  it("initRuntime is idempotent (same id, no rotation)", async () => {
+    const a = await initRuntime();
+    const b = await initRuntime();
+    expect(b).toBe(a);
+    expect(readDisk().device_id).toBe(a);
+  });
+});
+
+describe("logout preserves device_id", () => {
+  it("keeps device_id across logout so the install id is stable", async () => {
+    const id = await resolveDeviceId();
+    seed({ ...readDisk(), user_token: "u", refresh_token: "r" });
+    await clearCredentials();
+    expect(readDisk().device_id).toBe(id);
+    // Re-resolving after logout returns the SAME persisted id.
+    resetRuntimeForTests();
+    await expect(resolveDeviceId()).resolves.toBe(id);
+  });
+});
+
+describe("cross-process convergence (real child processes)", () => {
+  it("two concurrent first-run processes converge to ONE persisted device id", async () => {
+    const workerPath = fileURLToPath(new URL("./device-worker.ts", import.meta.url));
+    const barrier = Date.now() + 400;
+
+    const run = (): Promise<{ code: number; out: string; err: string }> =>
+      new Promise((resolve) => {
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          CHECKERS60_CREDS_PATH: credsPath,
+          BARRIER_TS: String(barrier),
+        };
+        delete env.CHECKERS60_DEVICE_ID;
+        const child = spawn(process.execPath, ["--import", "tsx", workerPath], {
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+        let out = "";
+        let err = "";
+        child.stdout.on("data", (d) => (out += d));
+        child.stderr.on("data", (d) => (err += d));
+        child.on("close", (code) => resolve({ code: code ?? 0, out, err }));
+      });
+
+    const [a, b] = await Promise.all([run(), run()]);
+
+    expect(a.code, `worker A failed: ${a.err}`).toBe(0);
+    expect(b.code, `worker B failed: ${b.err}`).toBe(0);
+
+    const idA = JSON.parse(a.out.trim()).deviceId as string;
+    const idB = JSON.parse(b.out.trim()).deviceId as string;
+    expect(idA).toMatch(/^[0-9a-f]{16}$/);
+    expect(idA).toBe(idB);
+    expect(readDisk().device_id).toBe(idA);
+  }, 20_000);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import { Command, Option } from "commander";
+import { Command, CommanderError, Option } from "commander";
 import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import { configureOutput } from "./lib/output.js";
-import { wrap, EXIT_USAGE } from "./lib/errors.js";
+import { configureOutput, isJson } from "./lib/output.js";
+import { wrap, handleError, UsageError, EXIT_USAGE } from "./lib/errors.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -17,6 +17,31 @@ try {
   version = pkg.version;
 } catch {}
 
+/** Detect JSON mode from argv (`--json` anywhere) or `CHECKERS60_JSON` env. */
+function detectJson(argv: readonly string[], env: NodeJS.ProcessEnv): boolean {
+  if (argv.includes("--json")) return true;
+  const v = env.CHECKERS60_JSON;
+  return (
+    v !== undefined && v !== "" && v !== "0" && v.toLowerCase() !== "false"
+  );
+}
+
+// Resolve JSON mode BEFORE commander parses, so usage errors are JSON too and
+// commander's own output is buffered/suppressed appropriately.
+const jsonMode = detectJson(process.argv, process.env);
+configureOutput({ json: jsonMode });
+
+// In JSON mode we buffer commander's own writes (help/version/error text) so it
+// can never leak before our single JSON envelope. On help/version success we
+// flush; on any usage failure we discard and emit exactly one envelope.
+const outBuffer: string[] = [];
+const errBuffer: string[] = [];
+
+/** Merge the global/env JSON flag with a per-command `--json` (explicit OR). */
+function mergeJson(opts?: { json?: boolean }): boolean {
+  return isJson() || Boolean(opts?.json);
+}
+
 const program = new Command()
   .name("checkers60")
   .description("CLI for Checkers Sixty60 grocery delivery (mobile-app API)")
@@ -24,27 +49,36 @@ const program = new Command()
   .addOption(new Option("--no-color", "disable colored output (respects NO_COLOR)"))
   .addOption(new Option("-q, --quiet", "suppress non-essential output").default(false))
   .addOption(new Option("-v, --verbose", "show extra debug info").default(false))
+  .addOption(new Option("--json", "output machine-readable JSON").default(false))
   .hook("preAction", (thisCommand) => {
     const opts = thisCommand.opts<{
       color?: boolean;
       quiet?: boolean;
       verbose?: boolean;
+      json?: boolean;
     }>();
     configureOutput({
       // Commander negates --no-color into opts.color === false
       noColor: opts.color === false,
       quiet: opts.quiet,
       verbose: opts.verbose,
+      json: isJson() || Boolean(opts.json),
     });
   })
   .showHelpAfterError()
-  .exitOverride((err) => {
-    // Invalid usage → exit 2 per clig.dev
-    if (err.code === "commander.unknownCommand" || err.code === "commander.unknownOption") {
-      process.exit(EXIT_USAGE);
-    }
-    process.exit(err.exitCode ?? 0);
-  });
+  .configureOutput({
+    writeOut: (str) => {
+      if (isJson()) outBuffer.push(str);
+      else process.stdout.write(str);
+    },
+    writeErr: (str) => {
+      if (isJson()) errBuffer.push(str);
+      else process.stderr.write(str);
+    },
+  })
+  // Throw commander errors so the single try/catch around parseAsync owns exit
+  // codes and (in JSON mode) the error envelope. Never process.exit here.
+  .exitOverride();
 
 program.addHelpText(
   "after",
@@ -69,10 +103,16 @@ Cart management:
   $ checkers60 cart suggestions        # See recommended items
   $ checkers60 cart promos             # See cart promotions
 
+Global flags:
+  --json  Emit machine-readable JSON (also via CHECKERS60_JSON=1). Errors become
+          a single {"error","code","status?"} object on stdout.
+
 Exit codes:
   0  success
   1  runtime failure
   2  invalid usage
+  3  authentication (not logged in / 401 / 403)
+  4  network (timeout, DNS, connection reset)
 `
 );
 
@@ -93,7 +133,7 @@ Examples:
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { otpTrigger } = await import("./commands/login.js");
-      await otpTrigger({ json: opts.json });
+      await otpTrigger({ json: mergeJson(opts) });
     })
   );
 
@@ -112,7 +152,7 @@ Examples:
   .action(
     wrap(async (reference: string, code: string, opts: { json?: boolean }) => {
       const { otpVerify } = await import("./commands/login.js");
-      await otpVerify(reference, code, { json: opts.json });
+      await otpVerify(reference, code, { json: mergeJson(opts) });
     })
   );
 
@@ -135,7 +175,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { status } = await import("./commands/status.js");
-      await status({ json: opts.json });
+      await status({ json: mergeJson(opts) });
     })
   );
 
@@ -160,7 +200,7 @@ Examples:
       await search(query, {
         page: parseInt(opts.page, 10),
         limit: parseInt(opts.limit, 10),
-        json: opts.json,
+        json: mergeJson(opts),
       });
     })
   );
@@ -173,7 +213,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { cart } = await import("./commands/cart.js");
-      await cart({ json: opts.json });
+      await cart({ json: mergeJson(opts) });
     })
   );
 
@@ -193,7 +233,7 @@ Examples:
   .action(
     wrap(async (target: string, qty: string | undefined, opts: { json?: boolean }) => {
       const { add } = await import("./commands/add.js");
-      await add(target, qty ? parseInt(qty, 10) : 1, { json: opts.json });
+      await add(target, qty ? parseInt(qty, 10) : 1, { json: mergeJson(opts) });
     })
   );
 
@@ -213,7 +253,7 @@ Examples:
   .action(
     wrap(async (target: string, opts: { json?: boolean }) => {
       const { remove } = await import("./commands/remove.js");
-      await remove(target, { json: opts.json });
+      await remove(target, { json: mergeJson(opts) });
     })
   );
 
@@ -225,7 +265,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { clear } = await import("./commands/clear.js");
-      await clear({ json: opts.json });
+      await clear({ json: mergeJson(opts) });
     })
   );
 
@@ -237,7 +277,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { addresses } = await import("./commands/addresses.js");
-      await addresses({ json: opts.json });
+      await addresses({ json: mergeJson(opts) });
     })
   );
 
@@ -249,7 +289,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { cards } = await import("./commands/cards.js");
-      await cards({ json: opts.json });
+      await cards({ json: mergeJson(opts) });
     })
   );
 
@@ -270,7 +310,7 @@ Examples:
   .action(
     wrap(async (opts: { all?: boolean; json?: boolean }) => {
       const { orders } = await import("./commands/orders.js");
-      await orders({ all: opts.all, json: opts.json });
+      await orders({ all: opts.all, json: mergeJson(opts) });
     })
   );
 
@@ -282,7 +322,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { profile } = await import("./commands/profile.js");
-      await profile({ json: opts.json });
+      await profile({ json: mergeJson(opts) });
     })
   );
 
@@ -294,7 +334,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { slots } = await import("./commands/slots.js");
-      await slots({ json: opts.json });
+      await slots({ json: mergeJson(opts) });
     })
   );
 
@@ -306,7 +346,7 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { categories } = await import("./commands/categories.js");
-      await categories({ json: opts.json });
+      await categories({ json: mergeJson(opts) });
     })
   );
 
@@ -318,12 +358,50 @@ program
   .action(
     wrap(async (opts: { json?: boolean }) => {
       const { trending } = await import("./commands/trending.js");
-      await trending({ json: opts.json });
+      await trending({ json: mergeJson(opts) });
     })
   );
 
-program.parseAsync().catch(() => {
-  // wrap()/exitOverride() already handle exit codes; this guards
-  // against unexpected commander errors.
-  process.exit(1);
-});
+function flushBuffers(): void {
+  if (outBuffer.length) {
+    process.stdout.write(outBuffer.join(""));
+    outBuffer.length = 0;
+  }
+  if (errBuffer.length) {
+    process.stderr.write(errBuffer.join(""));
+    errBuffer.length = 0;
+  }
+}
+
+function discardBuffers(): void {
+  outBuffer.length = 0;
+  errBuffer.length = 0;
+}
+
+// Single entry point: route EVERY error through handleError, which sets
+// process.exitCode and never calls process.exit — so buffered stdout flushes.
+try {
+  await program.parseAsync();
+} catch (err) {
+  if (err instanceof CommanderError) {
+    if (err.exitCode === 0) {
+      // Successful --help / --version: not an error. Flush any buffered
+      // help/version text (buffered only in JSON mode) and exit 0.
+      flushBuffers();
+      process.exitCode = 0;
+    } else {
+      // Any commander usage failure (unknown command/option, missing
+      // argument, …) → discard buffered text, exit 2. In JSON mode emit
+      // exactly one envelope; in human mode commander already wrote the
+      // message straight to stderr.
+      discardBuffers();
+      if (isJson()) {
+        handleError(new UsageError(err.message.replace(/^error:\s*/i, "")));
+      } else {
+        process.exitCode = EXIT_USAGE;
+      }
+    }
+  } else {
+    handleError(err);
+  }
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { configureOutput, isJson } from "./lib/output.js";
+import { initRuntime } from "./lib/runtime.js";
 import { wrap, handleError, UsageError, EXIT_USAGE } from "./lib/errors.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -50,7 +51,7 @@ const program = new Command()
   .addOption(new Option("-q, --quiet", "suppress non-essential output").default(false))
   .addOption(new Option("-v, --verbose", "show extra debug info").default(false))
   .addOption(new Option("--json", "output machine-readable JSON").default(false))
-  .hook("preAction", (thisCommand) => {
+  .hook("preAction", async (thisCommand) => {
     const opts = thisCommand.opts<{
       color?: boolean;
       quiet?: boolean;
@@ -64,6 +65,9 @@ const program = new Command()
       verbose: opts.verbose,
       json: isJson() || Boolean(opts.json),
     });
+    // Resolve the per-install device id once, before any command action builds
+    // headers or an API client. Runs after arg parse; not for --help/--version.
+    await initRuntime();
   })
   .showHelpAfterError()
   .configureOutput({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ const program = new Command()
   .addOption(new Option("-q, --quiet", "suppress non-essential output").default(false))
   .addOption(new Option("-v, --verbose", "show extra debug info").default(false))
   .addOption(new Option("--json", "output machine-readable JSON").default(false))
-  .hook("preAction", async (thisCommand) => {
+  .hook("preAction", async (thisCommand, actionCommand) => {
     const opts = thisCommand.opts<{
       color?: boolean;
       quiet?: boolean;
@@ -67,7 +67,12 @@ const program = new Command()
     });
     // Resolve the per-install device id once, before any command action builds
     // headers or an API client. Runs after arg parse; not for --help/--version.
-    await initRuntime();
+    // `logout` makes no API calls and needs no device id — and a corrupt creds
+    // file would make resolveDeviceId throw, blocking the very command meant to
+    // clear it — so skip runtime init for logout.
+    if (actionCommand.name() !== "logout") {
+      await initRuntime();
+    }
   })
   .showHelpAfterError()
   .configureOutput({
@@ -164,10 +169,11 @@ Examples:
 program
   .command("logout")
   .description("Clear saved tokens")
+  .option("--json", "Output JSON", false)
   .action(
-    wrap(async () => {
+    wrap(async (opts: { json?: boolean }) => {
       const { logout } = await import("./commands/logout.js");
-      await logout();
+      await logout({ json: mergeJson(opts) });
     })
   );
 

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { clearCredentials } from "../lib/credentials.js";
 
 export async function logout(): Promise<void> {
-  const cleared = clearCredentials();
+  const cleared = await clearCredentials();
   if (cleared) {
     process.stdout.write(`${chalk.green("✅ Logged out. Saved tokens cleared.")}\n`);
   } else {

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,8 +1,19 @@
 import chalk from "chalk";
 import { clearCredentials } from "../lib/credentials.js";
 
-export async function logout(): Promise<void> {
+export interface LogoutOptions {
+  json?: boolean;
+}
+
+export async function logout(options: LogoutOptions = {}): Promise<void> {
+  const { json = false } = options;
   const cleared = await clearCredentials();
+
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ cleared })}\n`);
+    return;
+  }
+
   if (cleared) {
     process.stdout.write(`${chalk.green("✅ Logged out. Saved tokens cleared.")}\n`);
   } else {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -301,7 +301,7 @@ export class CheckersAPI {
       `${CONFIG.CATALOG_API}/api/v3/products/filter?isCarousel=false&includePromotions=true&promotionChannel=sixty60&isXtraSavings=true&isXtraSavingsMember=true&particularMemberBonusBuyIds=&t=${t}`,
       // The catalog decodes a JSON body; the sibling getProductDetails call
       // uses `json` too. Sending it form-urlencoded returns 400 and broke search.
-      { headers, json: body }
+      { headers, json: body, retry: "safe" }
     );
 
     const products = (res.data?.products ?? []).map(mapCatalogProduct);
@@ -327,7 +327,7 @@ export class CheckersAPI {
     const res = await request<CatalogResponse>(
       "POST",
       `${CONFIG.CATALOG_API}/api/v3/products/filter?isCarousel=false&includePromotions=true&promotionChannel=sixty60&isXtraSavings=true`,
-      { headers, json: body }
+      { headers, json: body, retry: "safe" }
     );
     return res.data?.products ?? [];
   }
@@ -341,7 +341,7 @@ export class CheckersAPI {
     const res = await request<CartsResponse>(
       "POST",
       `${CONFIG.ORDERS_API}/api/v2/carts/user?useProductMinInfoAnnotation=true`,
-      { headers, json: { storeContexts } }
+      { headers, json: { storeContexts }, retry: "safe" }
     );
 
     const carts = res.data?.carts ?? [];
@@ -441,7 +441,7 @@ export class CheckersAPI {
     const res = await request<{ items?: Address[] }>(
       "GET",
       `${CONFIG.AUTH_API}/customers/${userId}/addresses`,
-      { headers }
+      { headers, retry: "safe" }
     );
     return res.data?.items ?? [];
   }
@@ -452,7 +452,7 @@ export class CheckersAPI {
     const res = await request<{ cards?: Card[] }>(
       "GET",
       `${CONFIG.AUTH_API}/customers/${userId}/cards`,
-      { headers }
+      { headers, retry: "safe" }
     );
     return res.data?.cards ?? [];
   }
@@ -464,7 +464,7 @@ export class CheckersAPI {
     const res = await request<{ orderGroups?: OrderGroup[] }>(
       "GET",
       `${CONFIG.ORDERS_API}/api/v1/orders/groups?activeOnly=${activeOnly}`,
-      { headers }
+      { headers, retry: "safe" }
     );
     return res.data?.orderGroups ?? [];
   }
@@ -556,6 +556,7 @@ export class CheckersAPI {
           "device-id": CONFIG.DEVICE_ID,
           "customer-id": CONFIG.SHOPRITE_UUID,
         },
+        retry: "safe",
       }
     );
     return res.data?.response?.user;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -404,7 +404,7 @@ export class CheckersAPI {
     );
 
     if (!res.data?.carts) {
-      throw new Error(`Cart update failed: ${JSON.stringify(res.data)}`);
+      throw new Error("Cart update failed");
     }
     const cart = res.data.carts[0]?.item;
     return {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,7 @@ import {
   type StoreContext,
 } from "./config.js";
 import { TokenManager } from "./credentials.js";
+import { getDeviceId } from "./runtime.js";
 import { request, APIError } from "./http.js";
 
 export { APIError };
@@ -238,7 +239,7 @@ export class CheckersAPI {
       "app-version": CONFIG.APP_VERSION,
       appversion: CONFIG.APP_VERSION_CODE,
       "istio-appversion": CONFIG.APP_VERSION_CODE,
-      "device-id": CONFIG.DEVICE_ID,
+      "device-id": getDeviceId(),
       "customer-id": CONFIG.SHOPRITE_UUID,
       userid: CONFIG.SIXTY60_USER_ID,
       mobilenumber: CONFIG.MOBILE,
@@ -553,7 +554,7 @@ export class CheckersAPI {
           "channel-os": CONFIG.APP_VERSION,
           "app-version": CONFIG.APP_VERSION,
           appversion: CONFIG.APP_VERSION_CODE,
-          "device-id": CONFIG.DEVICE_ID,
+          "device-id": getDeviceId(),
           "customer-id": CONFIG.SHOPRITE_UUID,
         },
         retry: "safe",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -106,7 +106,8 @@ export const CONFIG = {
   CHANNEL: "super-app",
   APP_VERSION: "Android 2.0.114 (1778865226)",
   APP_VERSION_CODE: "1778865226",
-  DEVICE_ID: env.CHECKERS60_DEVICE_ID || "e0ce1cc2565366d7",
+  // Per-install device id lives in module state (see runtime.ts); header
+  // builders read it via getDeviceId() after initRuntime() resolves it.
   USER_AGENT: "okhttp/4.12.0",
 
   // ── User identity (from env; two distinct IDs) ───────────────────────────

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,31 +1,20 @@
-import {
-  readFileSync,
-  writeFileSync,
-  existsSync,
-  mkdirSync,
-  unlinkSync,
-} from "node:fs";
-import { dirname } from "node:path";
+import { readFileSync, existsSync } from "node:fs";
 import { CONFIG } from "./config.js";
 import { request, APIError } from "./http.js";
+import {
+  withCredentialsLock,
+  updateBffTokenLocked,
+  updateUserTokensLocked,
+  updateOtpResultLocked,
+  updateIdentityLocked,
+  clearCredentialsStore,
+  type CredentialsFile,
+  type LockedContext,
+} from "./creds-store.js";
 
-/**
- * Shape of the on-disk credentials file
- * (~/.openclaw/credentials/checkers60.json).
- */
-export interface CredentialsFile {
-  bff_token?: string | null;
-  bff_expiry?: number;
-  user_token?: string | null;
-  refresh_token?: string | null;
-  user_expiry?: number;
-  mobile?: string;
-  customer_id?: string;
-  sixty60_user_id?: string;
-  profile_token?: string;
-  updated_at?: string;
-}
+export type { CredentialsFile };
 
+/** Read-only load. Degrades to logged-out ({}) on a missing/corrupt file. */
 export function loadCredentials(): CredentialsFile {
   try {
     if (existsSync(CONFIG.CREDS_PATH)) {
@@ -37,13 +26,13 @@ export function loadCredentials(): CredentialsFile {
   return {};
 }
 
-/** Delete the saved credentials file (used by `logout`). */
-export function clearCredentials(): boolean {
-  if (existsSync(CONFIG.CREDS_PATH)) {
-    unlinkSync(CONFIG.CREDS_PATH);
-    return true;
-  }
-  return false;
+/**
+ * Delete the saved credentials (used by `logout`). Runs under the credential
+ * lock and PRESERVES `device_id` so logout doesn't rotate the installation
+ * identity. Returns whether anything was cleared.
+ */
+export function clearCredentials(): Promise<boolean> {
+  return clearCredentialsStore();
 }
 
 interface ShopriteTokenResponse {
@@ -55,14 +44,20 @@ interface ShopriteTokenResponse {
   };
 }
 
+const NOT_LOGGED_IN =
+  "Not logged in. Run: checkers60 otp-trigger, then checkers60 otp-verify <reference> <code>";
+
 /**
  * Manages the three tokens the mobile API needs:
  *  - BFF Cognito JWT (24h, no auth required to obtain)
  *  - user access token (from OTP login, ~1h, auto-refreshes)
  *  - refresh token (long-lived, used to mint new access tokens)
  *
- * OTP is NEVER triggered automatically — callers must use the explicit
- * two-step `otp-trigger` / `otp-verify` flow.
+ * All persistence goes through the locked credential store (`creds-store.ts`):
+ * field-scoped, atomic, cross-process safe. In-memory fields are adopted from
+ * the committed on-disk state returned by each transaction. OTP is NEVER
+ * triggered automatically — callers use the explicit two-step
+ * `otp-trigger` / `otp-verify` flow.
  */
 export class TokenManager {
   bffToken: string | null = null;
@@ -77,35 +72,19 @@ export class TokenManager {
 
   private load(): void {
     const c = loadCredentials();
-    this.bffToken = c.bff_token ?? null;
-    this.bffExpiry = c.bff_expiry ?? 0;
-    this.userToken = c.user_token ?? null;
-    this.refreshToken = c.refresh_token ?? null;
-    this.userExpiry = c.user_expiry ?? 0;
+    this.adopt(c);
     // Credentials file overrides env defaults for these identity fields.
     if (c.sixty60_user_id) CONFIG.SIXTY60_USER_ID = c.sixty60_user_id;
     if (c.profile_token) CONFIG.PROFILE_TOKEN = c.profile_token;
   }
 
-  save(): void {
-    // Merge with any existing file to preserve unknown fields.
-    const existing = loadCredentials();
-    const creds: CredentialsFile = {
-      ...existing,
-      bff_token: this.bffToken,
-      bff_expiry: this.bffExpiry,
-      user_token: this.userToken,
-      refresh_token: this.refreshToken,
-      user_expiry: this.userExpiry,
-      mobile: CONFIG.MOBILE || existing.mobile,
-      customer_id: CONFIG.SHOPRITE_UUID || existing.customer_id,
-      sixty60_user_id: CONFIG.SIXTY60_USER_ID || existing.sixty60_user_id,
-      profile_token: CONFIG.PROFILE_TOKEN,
-      updated_at: new Date().toISOString(),
-    };
-    const dir = dirname(CONFIG.CREDS_PATH);
-    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    writeFileSync(CONFIG.CREDS_PATH, JSON.stringify(creds, null, 2));
+  /** Adopt in-memory token fields from committed on-disk state. */
+  private adopt(c: CredentialsFile): void {
+    this.bffToken = c.bff_token ?? null;
+    this.bffExpiry = c.bff_expiry ?? 0;
+    this.userToken = c.user_token ?? null;
+    this.refreshToken = c.refresh_token ?? null;
+    this.userExpiry = c.user_expiry ?? 0;
   }
 
   /** True if a non-expired user token (or a refresh token) is available. */
@@ -114,9 +93,16 @@ export class TokenManager {
     return Boolean(this.refreshToken);
   }
 
-  /** Get the BFF Cognito JWT (24h lifetime, no auth needed). */
-  async getBFFToken(): Promise<string> {
-    if (this.bffToken && Date.now() < this.bffExpiry - 60_000) return this.bffToken;
+  /**
+   * Ensure a valid BFF Cognito JWT inside an existing transaction (no re-lock).
+   * Reads fresh disk, refreshes over the network with `ctx.signal`, persists via
+   * `updateBffTokenLocked`, and returns the token.
+   */
+  async getBFFTokenLocked(ctx: LockedContext): Promise<string> {
+    const disk = await ctx.read();
+    if (disk.bff_token && Date.now() < (disk.bff_expiry ?? 0) - 60_000) {
+      return disk.bff_token;
+    }
 
     const res = await request<{ access_token?: string; expires_in?: number }>(
       "POST",
@@ -127,50 +113,83 @@ export class TokenManager {
           "device-id": CONFIG.DEVICE_ID,
           "content-length": "0",
         },
+        signal: ctx.signal,
       }
     );
     if (!res.data?.access_token) {
-      throw new Error(`BFF token request failed: ${JSON.stringify(res.data)}`);
+      throw new Error("BFF token request failed");
     }
 
-    this.bffToken = res.data.access_token;
-    this.bffExpiry = Date.now() + (res.data.expires_in ?? 86_400) * 1000;
-    this.save();
-    return this.bffToken;
+    const bffToken = res.data.access_token;
+    const bffExpiry = Date.now() + (res.data.expires_in ?? 86_400) * 1000;
+    const committed = await updateBffTokenLocked(ctx, { bffToken, bffExpiry });
+    this.adopt(committed);
+    return bffToken;
+  }
+
+  /**
+   * Get the BFF Cognito JWT (24h lifetime, no auth needed). With a locked `ctx`
+   * runs inside the existing transaction; without, opens its own transaction.
+   */
+  async getBFFToken(ctx?: LockedContext): Promise<string> {
+    if (ctx) return this.getBFFTokenLocked(ctx);
+    return withCredentialsLock((c) => this.getBFFTokenLocked(c));
   }
 
   /**
    * Get a valid user access token. Refreshes via the refresh token if needed,
-   * but NEVER triggers an OTP. Throws if no refresh token is available.
+   * but NEVER triggers an OTP. Throws if not logged in.
+   *
+   * Exact reconciliation sequence (§3.1): acquire the lock, read fresh disk,
+   * honor logout (no refresh token → logged out; never resurrect from memory),
+   * adopt any still-valid disk token without a network call, otherwise refresh
+   * against the authoritative disk refresh token (passing `ctx.signal`) and
+   * persist the new triple, keeping the old refresh token when the response
+   * omits a new one.
    */
   async getUserToken(): Promise<string> {
-    if (this.userToken && Date.now() < this.userExpiry - 60_000) return this.userToken;
+    const committed = await withCredentialsLock(async (ctx) => {
+      const disk = await ctx.read();
 
-    if (this.refreshToken) {
-      const bff = await this.getBFFToken();
+      // Honor logout/deletion: no refresh token on disk → logged out.
+      if (!disk.refresh_token) {
+        throw new Error(NOT_LOGGED_IN);
+      }
+
+      // Adopt a still-valid disk token with no network call — even if it equals
+      // memory (never refresh a valid identical token). Never use `updated_at`.
+      if (disk.user_token && Date.now() < (disk.user_expiry ?? 0) - 60_000) {
+        return disk;
+      }
+
+      const baseRefresh = disk.refresh_token;
+      const bff = await this.getBFFTokenLocked(ctx);
       const res = await request<ShopriteTokenResponse>(
         "GET",
-        `${CONFIG.SHOPRITE_BASE}/tokens?refreshToken=${encodeURIComponent(this.refreshToken)}`,
-        { headers: this.shopriteHeaders(bff) }
+        `${CONFIG.SHOPRITE_BASE}/tokens?refreshToken=${encodeURIComponent(baseRefresh)}`,
+        { headers: this.shopriteHeaders(bff), signal: ctx.signal }
       );
       const r = res.data?.response;
-      if (r?.accessToken) {
-        this.userToken = r.accessToken;
-        this.refreshToken = r.refreshToken ?? this.refreshToken;
-        this.userExpiry = Date.now() + (r.expiresIn ?? 3600) * 1000;
-        this.save();
-        return this.userToken;
+      if (!r?.accessToken) {
+        throw new Error("Token refresh failed");
       }
-    }
 
-    throw new Error(
-      "Not logged in. Run: checkers60 otp-trigger, then checkers60 otp-verify <reference> <code>"
-    );
+      return updateUserTokensLocked(ctx, {
+        userToken: r.accessToken,
+        // Never erase a still-valid refresh token when the response omits one.
+        refreshToken: r.refreshToken ?? baseRefresh,
+        userExpiry: Date.now() + (r.expiresIn ?? 3600) * 1000,
+      });
+    });
+
+    this.adopt(committed);
+    if (!committed.user_token) throw new Error(NOT_LOGGED_IN);
+    return committed.user_token;
   }
 
   /**
-   * Step 1 of login: send an OTP SMS to the configured mobile number.
-   * Returns the reference needed for verification.
+   * Step 1 of login: send an OTP SMS to the configured mobile number. Not inside
+   * the user-refresh lock; obtains a BFF token via its own transaction.
    */
   async triggerOtp(): Promise<string> {
     if (!CONFIG.MOBILE) {
@@ -186,14 +205,15 @@ export class TokenManager {
     );
     const reference = res.data?.response?.reference;
     if (!reference) {
-      throw new Error(`OTP trigger failed: ${JSON.stringify(res.data)}`);
+      throw new Error("OTP trigger failed");
     }
     return reference;
   }
 
   /**
-   * Step 2 of login: verify the OTP code against the reference from step 1
-   * and persist the resulting user + refresh tokens.
+   * Step 2 of login: verify the OTP code and persist the resulting tokens. The
+   * network verify runs OUTSIDE the user-refresh lock; the write uses its own
+   * transaction (`updateOtpResult` + `updateIdentity`).
    */
   async verifyOtp(reference: string, otp: string): Promise<void> {
     if (!CONFIG.MOBILE) {
@@ -215,12 +235,23 @@ export class TokenManager {
     );
     const r = res.data?.response;
     if (!r?.accessToken) {
-      throw new Error(`OTP verify failed: ${JSON.stringify(res.data)}`);
+      throw new Error("OTP verify failed");
     }
-    this.userToken = r.accessToken;
-    this.refreshToken = r.refreshToken ?? null;
-    this.userExpiry = Date.now() + (r.expiresIn ?? 3600) * 1000;
-    this.save();
+
+    const committed = await withCredentialsLock(async (ctx) => {
+      await updateOtpResultLocked(ctx, {
+        userToken: r.accessToken ?? null,
+        refreshToken: r.refreshToken ?? null,
+        userExpiry: Date.now() + (r.expiresIn ?? 3600) * 1000,
+      });
+      return updateIdentityLocked(ctx, {
+        mobile: CONFIG.MOBILE,
+        customer_id: CONFIG.SHOPRITE_UUID,
+        sixty60_user_id: CONFIG.SIXTY60_USER_ID,
+        profile_token: CONFIG.PROFILE_TOKEN,
+      });
+    });
+    this.adopt(committed);
   }
 
   /** Shoprite DSL auth headers (used for the BFF-token-protected endpoints). */

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync } from "node:fs";
 import { CONFIG } from "./config.js";
+import { getDeviceId } from "./runtime.js";
 import { request, APIError } from "./http.js";
 import {
   withCredentialsLock,
@@ -110,7 +111,7 @@ export class TokenManager {
       {
         headers: {
           channel: CONFIG.CHANNEL,
-          "device-id": CONFIG.DEVICE_ID,
+          "device-id": getDeviceId(),
           "content-length": "0",
         },
         signal: ctx.signal,
@@ -262,7 +263,7 @@ export class TokenManager {
       channel: CONFIG.CHANNEL,
       "app-version": CONFIG.APP_VERSION,
       appversion: CONFIG.APP_VERSION_CODE,
-      "device-id": CONFIG.DEVICE_ID,
+      "device-id": getDeviceId(),
     };
   }
 }

--- a/src/lib/creds-store.ts
+++ b/src/lib/creds-store.ts
@@ -1,0 +1,407 @@
+import { randomBytes } from "node:crypto";
+import { openSync, fsyncSync, closeSync, renameSync } from "node:fs";
+import {
+  open,
+  mkdir,
+  readFile,
+  readdir,
+  unlink,
+} from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+import lockfile from "proper-lockfile";
+import { CONFIG } from "./config.js";
+
+/**
+ * Shape of the on-disk credentials file
+ * (~/.openclaw/credentials/checkers60.json). This is the canonical definition;
+ * `credentials.ts` re-exports it for backwards compatibility.
+ */
+export interface CredentialsFile {
+  bff_token?: string | null;
+  bff_expiry?: number;
+  user_token?: string | null;
+  refresh_token?: string | null;
+  user_expiry?: number;
+  mobile?: string;
+  customer_id?: string;
+  sixty60_user_id?: string;
+  profile_token?: string;
+  device_id?: string;
+  updated_at?: string;
+}
+
+const DEFAULT_TX_DEADLINE_MS = 30_000;
+const DEFAULT_LOCK_TIMEOUT_MS = 30_000;
+/** Heartbeat interval — well under `stale` so a live tx keeps its lock fresh. */
+const LOCK_UPDATE_MS = 10_000;
+/** `stale` must sit strictly above the deadline so a runaway tx cannot renew past it. */
+const STALE_MARGIN_MS = 15_000;
+
+function txDeadlineMs(): number {
+  const raw = process.env.CHECKERS60_TX_DEADLINE_MS;
+  const n = raw ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TX_DEADLINE_MS;
+}
+
+function lockTimeoutMs(): number {
+  const raw = process.env.CHECKERS60_LOCK_TIMEOUT_MS;
+  const n = raw ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_LOCK_TIMEOUT_MS;
+}
+
+/** Regex matching this store's own temp files: `.<basename>.tmp.<pid>.<rand>`. */
+function orphanPattern(path: string): RegExp {
+  const base = basename(path).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^\\.${base}\\.tmp\\.\\d+\\.[0-9a-f]+$`);
+}
+
+function tempName(path: string): string {
+  return `.${basename(path)}.tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
+}
+
+async function ensureCredsDir(path: string): Promise<string> {
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  return dir;
+}
+
+function bestEffortFsyncDir(dir: string): void {
+  try {
+    const fd = openSync(dir, "r");
+    try {
+      fsyncSync(fd);
+    } finally {
+      closeSync(fd);
+    }
+  } catch {
+    // Directory fsync is best-effort — not all platforms support it.
+  }
+}
+
+/**
+ * Atomically write JSON to `path`:
+ *  - create the temp file IN the destination dir with `open(tmp, "wx", 0o600)`
+ *    (mode at creation — never write-then-chmod, which briefly exposes secrets
+ *    under a permissive umask),
+ *  - write, `fsync` the fd,
+ *  - run the optional synchronous commit `gate` (no `await` before `rename`),
+ *  - `renameSync` into place, best-effort `fsync` the parent dir,
+ *  - on any failure best-effort `unlink` the temp.
+ *
+ * A crash between temp-create and rename can leave an orphan; it is acceptable
+ * because it is mode `0600` (never exposes secrets) and a later {@link sweepOrphans}
+ * removes it.
+ */
+export async function atomicWriteJson(
+  path: string,
+  data: CredentialsFile,
+  gate?: () => void
+): Promise<void> {
+  const dir = await ensureCredsDir(path);
+  const tmp = join(dir, tempName(path));
+  const json = `${JSON.stringify(data, null, 2)}\n`;
+
+  let fh: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    fh = await open(tmp, "wx", 0o600);
+    await fh.writeFile(json, "utf8");
+    await fh.sync();
+    await fh.close();
+    fh = undefined;
+    // Commit gate: synchronous check with NO await before renameSync, closing
+    // the theft-to-write race so a timed-out/stolen tx can never commit.
+    if (gate) gate();
+    renameSync(tmp, path);
+  } catch (err) {
+    if (fh) {
+      try {
+        await fh.close();
+      } catch {
+        // ignore
+      }
+    }
+    try {
+      await unlink(tmp);
+    } catch {
+      // best-effort temp cleanup
+    }
+    throw err;
+  }
+
+  bestEffortFsyncDir(dir);
+}
+
+export class CredentialsCorruptError extends Error {
+  constructor(path: string, cause: unknown) {
+    super(`Credentials file is corrupt and cannot be parsed: ${basename(path)}`);
+    this.name = "CredentialsCorruptError";
+    this.cause = cause;
+  }
+}
+
+export class TransactionAbortedError extends Error {
+  constructor(reason: string) {
+    super(`Credential transaction aborted: ${reason}`);
+    this.name = "TransactionAbortedError";
+  }
+}
+
+/**
+ * Read the credentials file. Missing file → `{}`. A parse error is a HARD error
+ * (`CredentialsCorruptError`) so a write transaction never treats corruption as
+ * `{}` and overwrites recoverable tokens. Read-only callers can pass
+ * `lenient: true` to degrade to logged-out on corruption.
+ */
+export async function readCredentials(
+  path: string,
+  lenient = false
+): Promise<CredentialsFile> {
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return {};
+    throw err;
+  }
+  try {
+    return JSON.parse(raw) as CredentialsFile;
+  } catch (err) {
+    if (lenient) return {};
+    throw new CredentialsCorruptError(path, err);
+  }
+}
+
+/**
+ * Remove crash-orphan temp files for `path`. MUST be called only while holding
+ * the credential lock (writes are serialized, so no other writer has a live
+ * temp), and matches ONLY this store's validated pattern
+ * `.<basename>.tmp.<pid>.<rand>` — so it can never delete another writer's temp.
+ */
+export async function sweepOrphans(path: string): Promise<void> {
+  const dir = dirname(path);
+  const pattern = orphanPattern(path);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return;
+  }
+  await Promise.all(
+    entries
+      .filter((name) => pattern.test(name))
+      .map((name) =>
+        unlink(join(dir, name)).catch(() => {
+          // best-effort — another process may have swept it first
+        })
+      )
+  );
+}
+
+/** Locked transaction context handed to `withCredentialsLock` callbacks. */
+export interface LockedContext {
+  /** Fresh read of the on-disk state; hard error on corrupt JSON. */
+  read(): Promise<CredentialsFile>;
+  /** Merge `patch` onto fresh disk state, atomic-write, return committed state. */
+  writePatch(patch: Partial<CredentialsFile>): Promise<CredentialsFile>;
+  /** Replace the file wholesale (used by logout to write a device-only file). */
+  writeFull(state: CredentialsFile): Promise<CredentialsFile>;
+  /** The transaction's abort signal — passed to every in-lock network call. */
+  signal: AbortSignal;
+}
+
+export interface LockOptions {
+  /** Override the transaction deadline (ms). Defaults to CHECKERS60_TX_DEADLINE_MS or 30s. */
+  deadlineMs?: number;
+}
+
+/**
+ * Acquire the credential lock once and run `fn` inside a bounded transaction.
+ *
+ * A hard `TX_DEADLINE_MS` (default 30s) runs from acquisition through commit; a
+ * single deadline timer and `onCompromised` both abort a shared `txAbort`
+ * controller and set a `compromised` flag. Every write goes through a synchronous
+ * commit gate that rejects if compromised / aborted / past-deadline, with no
+ * `await` before the `rename`. Returns whatever `fn` returns; callers that need
+ * the committed state have their updaters return it.
+ */
+export async function withCredentialsLock<T>(
+  fn: (ctx: LockedContext) => Promise<T>,
+  options: LockOptions = {}
+): Promise<T> {
+  const path = CONFIG.CREDS_PATH;
+  const deadlineMs = options.deadlineMs ?? txDeadlineMs();
+  const staleMs = deadlineMs + STALE_MARGIN_MS;
+
+  // Parent dir must exist BEFORE proper-lockfile creates its `<file>.lock` dir.
+  await ensureCredsDir(path);
+
+  let compromised = false;
+  const txAbort = new AbortController();
+
+  const release = await lockfile.lock(path, {
+    realpath: false,
+    stale: staleMs,
+    update: LOCK_UPDATE_MS,
+    retries: {
+      retries: 100,
+      factor: 1.5,
+      minTimeout: 50,
+      maxTimeout: 1_000,
+      maxRetryTime: lockTimeoutMs(),
+      randomize: true,
+    },
+    onCompromised: () => {
+      // MUST NOT throw — that would surface as an uncaught async rejection.
+      compromised = true;
+      if (!txAbort.signal.aborted) txAbort.abort();
+    },
+  });
+
+  const deadlineAt = Date.now() + deadlineMs;
+  const deadlineTimer = setTimeout(() => {
+    if (!txAbort.signal.aborted) txAbort.abort();
+  }, deadlineMs);
+
+  const gate = (): void => {
+    if (compromised) throw new TransactionAbortedError("lock compromised");
+    if (txAbort.signal.aborted) throw new TransactionAbortedError("aborted");
+    if (Date.now() > deadlineAt) throw new TransactionAbortedError("deadline exceeded");
+  };
+
+  const ctx: LockedContext = {
+    read: () => readCredentials(path),
+    writePatch: async (patch) => {
+      const disk = await readCredentials(path);
+      const next: CredentialsFile = {
+        ...disk,
+        ...patch,
+        updated_at: new Date().toISOString(),
+      };
+      await atomicWriteJson(path, next, gate);
+      return next;
+    },
+    writeFull: async (state) => {
+      const next: CredentialsFile = { ...state, updated_at: new Date().toISOString() };
+      await atomicWriteJson(path, next, gate);
+      return next;
+    },
+    signal: txAbort.signal,
+  };
+
+  try {
+    // Sweep crash orphans while holding the lock, before any temp of ours exists.
+    await sweepOrphans(path);
+    return await fn(ctx);
+  } finally {
+    clearTimeout(deadlineTimer);
+    await release().catch(() => {
+      // lock may already be gone if it was compromised/stolen
+    });
+  }
+}
+
+// ── Field-scoped updaters ──────────────────────────────────────────────────
+// Each has a `*Locked(ctx, …)` variant (used inside an existing transaction,
+// no re-lock) and a public variant (opens its own `withCredentialsLock`). Each
+// merges only its own fields and returns the committed on-disk state.
+
+export interface BffFields {
+  bffToken: string | null;
+  bffExpiry: number;
+}
+
+export function updateBffTokenLocked(
+  ctx: LockedContext,
+  fields: BffFields
+): Promise<CredentialsFile> {
+  return ctx.writePatch({ bff_token: fields.bffToken, bff_expiry: fields.bffExpiry });
+}
+
+export function updateBffToken(fields: BffFields): Promise<CredentialsFile> {
+  return withCredentialsLock((ctx) => updateBffTokenLocked(ctx, fields));
+}
+
+export interface UserTokenFields {
+  userToken: string | null;
+  refreshToken: string | null;
+  userExpiry: number;
+}
+
+export function updateUserTokensLocked(
+  ctx: LockedContext,
+  fields: UserTokenFields
+): Promise<CredentialsFile> {
+  return ctx.writePatch({
+    user_token: fields.userToken,
+    refresh_token: fields.refreshToken,
+    user_expiry: fields.userExpiry,
+  });
+}
+
+export function updateUserTokens(fields: UserTokenFields): Promise<CredentialsFile> {
+  return withCredentialsLock((ctx) => updateUserTokensLocked(ctx, fields));
+}
+
+/** OTP verification result: same token triple, persisted as one atomic unit. */
+export function updateOtpResultLocked(
+  ctx: LockedContext,
+  fields: UserTokenFields
+): Promise<CredentialsFile> {
+  return updateUserTokensLocked(ctx, fields);
+}
+
+export function updateOtpResult(fields: UserTokenFields): Promise<CredentialsFile> {
+  return withCredentialsLock((ctx) => updateOtpResultLocked(ctx, fields));
+}
+
+export interface IdentityFields {
+  mobile?: string;
+  customer_id?: string;
+  sixty60_user_id?: string;
+  profile_token?: string;
+}
+
+export function updateIdentityLocked(
+  ctx: LockedContext,
+  fields: IdentityFields
+): Promise<CredentialsFile> {
+  const patch: Partial<CredentialsFile> = {};
+  if (fields.mobile) patch.mobile = fields.mobile;
+  if (fields.customer_id) patch.customer_id = fields.customer_id;
+  if (fields.sixty60_user_id) patch.sixty60_user_id = fields.sixty60_user_id;
+  if (fields.profile_token) patch.profile_token = fields.profile_token;
+  return ctx.writePatch(patch);
+}
+
+export function updateIdentity(fields: IdentityFields): Promise<CredentialsFile> {
+  return withCredentialsLock((ctx) => updateIdentityLocked(ctx, fields));
+}
+
+export function updateDeviceIdLocked(
+  ctx: LockedContext,
+  deviceId: string
+): Promise<CredentialsFile> {
+  return ctx.writePatch({ device_id: deviceId });
+}
+
+export function updateDeviceId(deviceId: string): Promise<CredentialsFile> {
+  return withCredentialsLock((ctx) => updateDeviceIdLocked(ctx, deviceId));
+}
+
+/**
+ * Logout: runs under the lock, deletes token/identity fields but PRESERVES
+ * `device_id` (rewrites a device-only file rather than unlinking) so logout does
+ * not rotate the installation identity. Returns whether a file existed.
+ */
+export async function clearCredentialsStore(): Promise<boolean> {
+  return withCredentialsLock(async (ctx) => {
+    // Lenient: a corrupt file must still be clearable, even if device_id is lost.
+    const disk = await readCredentials(CONFIG.CREDS_PATH, true).catch(() => ({} as CredentialsFile));
+    const existed = Object.keys(disk).length > 0;
+    if (!existed) return false;
+    // Preserve device_id; drop every token/identity field.
+    const deviceOnly: CredentialsFile = disk.device_id ? { device_id: disk.device_id } : {};
+    await ctx.writeFull(deviceOnly);
+    return true;
+  });
+}

--- a/src/lib/creds-store.ts
+++ b/src/lib/creds-store.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto";
-import { openSync, fsyncSync, closeSync, renameSync } from "node:fs";
+import { openSync, fsyncSync, closeSync, renameSync, existsSync } from "node:fs";
 import {
   open,
   mkdir,
@@ -177,7 +177,7 @@ export async function readCredentials(
  * temp), and matches ONLY this store's validated pattern
  * `.<basename>.tmp.<pid>.<rand>` — so it can never delete another writer's temp.
  */
-export async function sweepOrphans(path: string): Promise<void> {
+async function sweepOrphans(path: string): Promise<void> {
   const dir = dirname(path);
   const pattern = orphanPattern(path);
   let entries: string[];
@@ -394,13 +394,22 @@ export function updateDeviceId(deviceId: string): Promise<CredentialsFile> {
  * not rotate the installation identity. Returns whether a file existed.
  */
 export async function clearCredentialsStore(): Promise<boolean> {
+  // File existence MUST be determined independently of parseability: a corrupt
+  // file parses to nothing but still holds secrets on disk and must be cleared.
+  const existed = existsSync(CONFIG.CREDS_PATH);
   return withCredentialsLock(async (ctx) => {
-    // Lenient: a corrupt file must still be clearable, even if device_id is lost.
-    const disk = await readCredentials(CONFIG.CREDS_PATH, true).catch(() => ({} as CredentialsFile));
-    const existed = Object.keys(disk).length > 0;
+    // Nothing on disk → nothing to clear; never manufacture an empty creds file.
     if (!existed) return false;
-    // Preserve device_id; drop every token/identity field.
-    const deviceOnly: CredentialsFile = disk.device_id ? { device_id: disk.device_id } : {};
+    // Best-effort recover device_id so logout doesn't rotate identity. A corrupt
+    // file yields no device_id — but we ALWAYS overwrite, never leave secrets.
+    let deviceId: string | undefined;
+    try {
+      const disk = await readCredentials(CONFIG.CREDS_PATH);
+      deviceId = disk.device_id;
+    } catch {
+      deviceId = undefined;
+    }
+    const deviceOnly: CredentialsFile = deviceId ? { device_id: deviceId } : {};
     await ctx.writeFull(deviceOnly);
     return true;
   });

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,59 +1,121 @@
 import chalk from "chalk";
+import { writeSync } from "node:fs";
 import { APIError } from "./api.js";
-import { isVerbose, logError } from "./output.js";
+import { isJson, isVerbose, logError } from "./output.js";
 
 /**
- * Exit codes (clig.dev):
+ * Exit codes:
  *   0 — success
- *   1 — runtime failure
+ *   1 — generic runtime failure
  *   2 — invalid usage
+ *   3 — authentication (401/403, not logged in)
+ *   4 — network (timeout, DNS, connection reset/refused)
  */
 export const EXIT_OK = 0;
 export const EXIT_FAILURE = 1;
 export const EXIT_USAGE = 2;
+export const EXIT_AUTH = 3;
+export const EXIT_NETWORK = 4;
 
 export class UsageError extends Error {
   readonly isUsage = true;
 }
 
-export function handleError(err: unknown): never {
+interface Classified {
+  /** User-facing message. Never contains a response body or secret. */
+  message: string;
+  code: number;
+  /** HTTP status, when the failure came from a server response. */
+  status?: number;
+  /** Verbose-only, URL-redacted status line (never a body). */
+  verboseLine?: string;
+}
+
+const NETWORK_RE =
+  /(fetch failed|ENOTFOUND|EAI_AGAIN|ECONN(?:REFUSED|RESET|ABORTED)?|ETIMEDOUT|network|timed out|The (?:user aborted|operation was aborted)|This operation was aborted|AbortError)/i;
+
+function isNetworkError(err: Error): boolean {
+  if (err.name === "AbortError" || err.name === "TimeoutError") return true;
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code && /^(ENOTFOUND|EAI_AGAIN|ECONNREFUSED|ECONNRESET|ECONNABORTED|ETIMEDOUT)$/.test(code)) {
+    return true;
+  }
+  return NETWORK_RE.test(err.message);
+}
+
+/**
+ * Maps an unknown error to a user-facing message + exit code, WITHOUT ever
+ * leaking a response body or secret. APIError.message embeds up to 200 chars
+ * of the raw response body, so it is never surfaced — a clean message is built
+ * from status/statusText instead.
+ */
+export function classifyError(err: unknown): Classified {
   if (err instanceof UsageError) {
-    logError(err.message);
-    process.exit(EXIT_USAGE);
+    return { message: err.message, code: EXIT_USAGE };
   }
 
   if (err instanceof APIError) {
     if (err.status === 401 || err.status === 403) {
-      logError(`Authentication failed (HTTP ${err.status}).`);
-      process.stderr.write(
-        `${chalk.dim("   Your token may have expired. Run: ")}${chalk.cyan("checkers60 login")}${chalk.dim(", then ")}${chalk.cyan("checkers60 otp-verify <reference> <code>")}\n`
-      );
-    } else {
-      logError(`Request failed: HTTP ${err.status} ${err.statusText}`);
-      if (isVerbose() && err.body) {
-        process.stderr.write(chalk.dim(`   ${err.body.slice(0, 500)}\n`));
-      }
+      return {
+        message: `Authentication failed (HTTP ${err.status}).`,
+        code: EXIT_AUTH,
+        status: err.status,
+      };
     }
-    process.exit(EXIT_FAILURE);
+    return {
+      message: `Request failed: HTTP ${err.status} ${err.statusText}`,
+      code: EXIT_FAILURE,
+      status: err.status,
+      verboseLine: `${err.status} ${err.statusText} on ${err.path}`,
+    };
   }
 
   if (err instanceof Error) {
     if (/Not logged in/i.test(err.message)) {
-      logError(err.message);
-      process.stderr.write(
-        `${chalk.dim("   Run: ")}${chalk.cyan("checkers60 login")}${chalk.dim(" to sign in.")}\n`
-      );
-      process.exit(EXIT_FAILURE);
+      return { message: err.message, code: EXIT_AUTH };
     }
-    logError(err.message);
-    if (isVerbose() && err.stack) {
-      process.stderr.write(chalk.dim(`${err.stack}\n`));
+    if (isNetworkError(err)) {
+      return { message: err.message, code: EXIT_NETWORK };
     }
-    process.exit(EXIT_FAILURE);
+    return { message: err.message, code: EXIT_FAILURE };
   }
 
-  logError(String(err));
-  process.exit(EXIT_FAILURE);
+  return { message: String(err), code: EXIT_FAILURE };
+}
+
+/**
+ * Terminal error handler. Sets process.exitCode and returns — NEVER calls
+ * process.exit(), so buffered stdout is allowed to flush.
+ *
+ * In JSON mode it writes exactly one `{error, code, status?}` object to stdout
+ * (synchronous) and emits nothing else. In human mode it prints a friendly
+ * message (and, when verbose, a URL-redacted status line — never a body).
+ */
+export function handleError(err: unknown): void {
+  const c = classifyError(err);
+  process.exitCode = c.code;
+
+  if (isJson()) {
+    const envelope: { error: string; code: number; status?: number } = {
+      error: c.message,
+      code: c.code,
+    };
+    if (c.status !== undefined) envelope.status = c.status;
+    writeSync(1, `${JSON.stringify(envelope)}\n`);
+    return;
+  }
+
+  logError(c.message);
+
+  if (c.code === EXIT_AUTH && (err instanceof APIError || /Not logged in/i.test(c.message))) {
+    process.stderr.write(
+      `${chalk.dim("   Run: ")}${chalk.cyan("checkers60 login")}${chalk.dim(", then ")}${chalk.cyan("checkers60 otp-verify <reference> <code>")}\n`
+    );
+  }
+
+  if (isVerbose() && c.verboseLine) {
+    process.stderr.write(chalk.dim(`   ${c.verboseLine}\n`));
+  }
 }
 
 /**

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -5,7 +5,9 @@ export class APIError extends Error {
     public status: number,
     public statusText: string,
     public body: string,
-    public path: string
+    public path: string,
+    /** Raw `Retry-After` header value, when the server sent one. */
+    public retryAfter?: string
   ) {
     super(`API ${status} ${statusText} on ${path}: ${body.slice(0, 200)}`);
     this.name = "APIError";
@@ -62,12 +64,104 @@ export interface RequestOptions {
    * form key with an empty value, i.e. `encodeURIComponent(JSON.stringify(x)) + "="`.
    */
   form?: unknown;
+  /** Per-attempt timeout (fetch + body read). Defaults to 30s. */
   timeoutMs?: number;
   /**
    * External abort signal. Combined with the per-call timeout into one effective
    * abort; if it fires, the call rejects with {@link ExternalAbortError} (terminal).
    */
   signal?: AbortSignal;
+  /**
+   * Retry policy. `"never"` (the default) makes exactly one attempt. `"safe"`
+   * — reserved for provably side-effect-free reads — retries up to
+   * {@link MAX_ATTEMPTS} times on pre-response network errors, per-attempt
+   * timeouts, and HTTP 429/502/503/504. An external abort is NEVER retried.
+   */
+  retry?: "safe" | "never";
+  /**
+   * Overall wall-clock budget for a `"safe"` call, spanning every attempt, its
+   * body read, and the backoff waits between them. Defaults to 90s.
+   */
+  retryBudgetMs?: number;
+  /** Base for exponential backoff between `"safe"` attempts. Defaults to 300ms. */
+  backoffBaseMs?: number;
+  /** Ceiling for a single computed backoff wait. Defaults to 8s. */
+  backoffCapMs?: number;
+  /** Ceiling applied to a server-provided `Retry-After`. Defaults to 20s. */
+  retryAfterCapMs?: number;
+}
+
+/** Hard ceiling on attempts for a `retry:"safe"` call. */
+export const MAX_ATTEMPTS = 3;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_RETRY_BUDGET_MS = 90_000;
+const DEFAULT_BACKOFF_BASE_MS = 300;
+const DEFAULT_BACKOFF_CAP_MS = 8_000;
+const DEFAULT_RETRY_AFTER_CAP_MS = 20_000;
+const RETRYABLE_STATUS = new Set([429, 502, 503, 504]);
+
+/** An external abort ({@link ExternalAbortError} or any `{ external: true }` marker). */
+function isExternalAbort(err: unknown): boolean {
+  return Boolean(err && typeof err === "object" && (err as { external?: unknown }).external === true);
+}
+
+/**
+ * Whether a failed attempt may be retried by a `"safe"` call. External aborts are
+ * terminal and handled before this is consulted. An {@link APIError} is retryable
+ * only for 429/502/503/504; every other network-level failure (including a
+ * per-attempt {@link TimeoutError}) is treated as a retryable pre-response error.
+ */
+function isRetryable(err: unknown): boolean {
+  if (isExternalAbort(err)) return false;
+  if (err instanceof APIError) return RETRYABLE_STATUS.has(err.status);
+  return true;
+}
+
+/**
+ * Parse a `Retry-After` header — both the delta-seconds form (`"120"`) and the
+ * HTTP-date form (`"Wed, 21 Oct 2026 07:28:00 GMT"`) — into milliseconds,
+ * clamped to `[0, capMs]`. Returns `undefined` when absent or unparseable.
+ */
+export function parseRetryAfter(
+  value: string | undefined | null,
+  capMs: number
+): number | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  let ms: number;
+  if (/^\d+$/.test(trimmed)) {
+    ms = Number(trimmed) * 1000;
+  } else {
+    const when = Date.parse(trimmed);
+    if (Number.isNaN(when)) return undefined;
+    ms = when - Date.now();
+  }
+  if (Number.isNaN(ms)) return undefined;
+  return Math.max(0, Math.min(ms, capMs));
+}
+
+/** Abortable delay. Resolves after `ms`; rejects with {@link ExternalAbortError} if `signal` fires. */
+function abortableSleep(
+  ms: number,
+  signal: AbortSignal | undefined,
+  method: string,
+  redactedUrl: string
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new ExternalAbortError(method, redactedUrl));
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new ExternalAbortError(method, redactedUrl));
+    };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
 }
 
 export interface ApiResponse<T> {
@@ -85,7 +179,18 @@ export async function request<T = unknown>(
   url: string,
   options: RequestOptions = {}
 ): Promise<ApiResponse<T>> {
-  const { headers = {}, json, form, timeoutMs = 30_000, signal } = options;
+  const {
+    headers = {},
+    json,
+    form,
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    signal,
+    retry = "never",
+    retryBudgetMs = DEFAULT_RETRY_BUDGET_MS,
+    backoffBaseMs = DEFAULT_BACKOFF_BASE_MS,
+    backoffCapMs = DEFAULT_BACKOFF_CAP_MS,
+    retryAfterCapMs = DEFAULT_RETRY_AFTER_CAP_MS,
+  } = options;
 
   const finalHeaders: Record<string, string> = {
     accept: "application/json, text/plain, */*",
@@ -94,6 +199,8 @@ export async function request<T = unknown>(
     ...headers,
   };
 
+  // Body + headers (and any ids they carry) are built ONCE and reused identically
+  // across every retry attempt.
   let body: string | undefined;
   if (form !== undefined) {
     // App quirk: form-urlencoded content-type, JSON payload as a form key.
@@ -104,6 +211,63 @@ export async function request<T = unknown>(
     body = JSON.stringify(json);
   }
 
+  // `retry:"never"` — exactly one attempt; original behaviour preserved.
+  if (retry !== "safe") {
+    return attemptRequest<T>(method, url, finalHeaders, body, timeoutMs, signal);
+  }
+
+  const redacted = redactUrl(url);
+  const deadline = Date.now() + retryBudgetMs;
+  let lastErr: unknown;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+
+    try {
+      // The per-attempt timeout is bounded by whatever overall budget remains, so
+      // the budget also caps a single attempt (fetch + body read).
+      const perAttempt = Math.min(timeoutMs, remaining);
+      return await attemptRequest<T>(method, url, finalHeaders, body, perAttempt, signal);
+    } catch (err) {
+      // An external abort is terminal: never retried, never relabeled as a timeout.
+      if (isExternalAbort(err)) throw err;
+      lastErr = err;
+      if (attempt === MAX_ATTEMPTS - 1 || !isRetryable(err)) throw err;
+
+      const retryAfterMs =
+        err instanceof APIError ? parseRetryAfter(err.retryAfter, retryAfterCapMs) : undefined;
+      const delay =
+        retryAfterMs !== undefined
+          ? retryAfterMs
+          : Math.random() * Math.min(backoffCapMs, backoffBaseMs * 2 ** attempt);
+
+      // Not enough budget to both wait and try again → stop now with the last error.
+      if (delay >= deadline - Date.now()) throw err;
+      // Backoff is abortable: an external abort during the wait is terminal.
+      await abortableSleep(delay, signal, method, redacted);
+    }
+  }
+
+  throw lastErr;
+}
+
+/**
+ * A single HTTP attempt: fetch + body read under one combined abort (the
+ * per-attempt timeout fanned in with the external signal). The abort stays active
+ * THROUGH the body read so a hung `resp.text()` can be cancelled. Rejects with
+ * {@link ExternalAbortError} (terminal) on external abort, {@link TimeoutError} on
+ * the per-attempt timeout, and {@link APIError} on a non-2xx response (carrying the
+ * `Retry-After` header for the retry policy to honor).
+ */
+async function attemptRequest<T>(
+  method: string,
+  url: string,
+  finalHeaders: Record<string, string>,
+  body: string | undefined,
+  timeoutMs: number,
+  signal: AbortSignal | undefined
+): Promise<ApiResponse<T>> {
   const controller = new AbortController();
   let timedOut = false;
   const timer = setTimeout(() => {
@@ -122,9 +286,6 @@ export async function request<T = unknown>(
   }
 
   try {
-    // The abort must stay active THROUGH the body read: fetch() and resp.text()
-    // both run inside the timed/abortable window so a hung body read can be
-    // cancelled by the timeout or the external signal.
     const resp = await fetch(url, {
       method,
       headers: finalHeaders,
@@ -142,7 +303,13 @@ export async function request<T = unknown>(
     }
 
     if (!resp.ok) {
-      throw new APIError(resp.status, resp.statusText, text, new URL(url).pathname);
+      throw new APIError(
+        resp.status,
+        resp.statusText,
+        text,
+        new URL(url).pathname,
+        resp.headers.get("retry-after") ?? undefined
+      );
     }
 
     return { status: resp.status, headers: resp.headers, data: data as T };

--- a/src/lib/http.ts
+++ b/src/lib/http.ts
@@ -12,6 +12,46 @@ export class APIError extends Error {
   }
 }
 
+/**
+ * Thrown when the per-call timeout elapses. Distinct from {@link ExternalAbortError}
+ * so a later retry policy can treat a timeout as retryable while an external abort
+ * stays terminal.
+ */
+export class TimeoutError extends Error {
+  readonly timeout = true;
+  constructor(
+    public timeoutMs: number,
+    method: string,
+    redactedUrl: string
+  ) {
+    super(`Request timed out after ${timeoutMs}ms: ${method} ${redactedUrl}`);
+    this.name = "TimeoutError";
+  }
+}
+
+/**
+ * Thrown when an external {@link AbortSignal} passed via `options.signal` aborts
+ * the call. Terminal: a later retry policy must never retry it and must never
+ * relabel it as a timeout. Carries `external === true` as the discriminator.
+ */
+export class ExternalAbortError extends Error {
+  readonly external = true;
+  constructor(method: string, redactedUrl: string) {
+    super(`Request aborted: ${method} ${redactedUrl}`);
+    this.name = "AbortError";
+  }
+}
+
+/** Origin + pathname only — strips query string (and any refresh token in it). */
+export function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return `${u.origin}${u.pathname}`;
+  } catch {
+    return url.split("?")[0];
+  }
+}
+
 export interface RequestOptions {
   headers?: Record<string, string>;
   /** JSON body — serialized with JSON.stringify and `application/json`. */
@@ -23,6 +63,11 @@ export interface RequestOptions {
    */
   form?: unknown;
   timeoutMs?: number;
+  /**
+   * External abort signal. Combined with the per-call timeout into one effective
+   * abort; if it fires, the call rejects with {@link ExternalAbortError} (terminal).
+   */
+  signal?: AbortSignal;
 }
 
 export interface ApiResponse<T> {
@@ -40,7 +85,7 @@ export async function request<T = unknown>(
   url: string,
   options: RequestOptions = {}
 ): Promise<ApiResponse<T>> {
-  const { headers = {}, json, form, timeoutMs = 30_000 } = options;
+  const { headers = {}, json, form, timeoutMs = 30_000, signal } = options;
 
   const finalHeaders: Record<string, string> = {
     accept: "application/json, text/plain, */*",
@@ -60,38 +105,60 @@ export async function request<T = unknown>(
   }
 
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
 
-  let resp: Response;
+  let onExternalAbort: (() => void) | undefined;
+  if (signal) {
+    if (signal.aborted) {
+      controller.abort();
+    } else {
+      onExternalAbort = () => controller.abort();
+      signal.addEventListener("abort", onExternalAbort, { once: true });
+    }
+  }
+
   try {
-    resp = await fetch(url, {
+    // The abort must stay active THROUGH the body read: fetch() and resp.text()
+    // both run inside the timed/abortable window so a hung body read can be
+    // cancelled by the timeout or the external signal.
+    const resp = await fetch(url, {
       method,
       headers: finalHeaders,
       body,
       signal: controller.signal,
       redirect: "follow",
     });
+
+    const text = await resp.text();
+    let data: unknown;
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+
+    if (!resp.ok) {
+      throw new APIError(resp.status, resp.statusText, text, new URL(url).pathname);
+    }
+
+    return { status: resp.status, headers: resp.headers, data: data as T };
   } catch (err) {
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error(`Request timed out after ${timeoutMs}ms: ${method} ${url}`);
+      // External abort takes precedence and is terminal — never relabel it as a timeout.
+      if (signal?.aborted) {
+        throw new ExternalAbortError(method, redactUrl(url));
+      }
+      if (timedOut) {
+        throw new TimeoutError(timeoutMs, method, redactUrl(url));
+      }
     }
     throw err;
   } finally {
     clearTimeout(timer);
+    if (onExternalAbort) signal?.removeEventListener("abort", onExternalAbort);
   }
-
-  const text = await resp.text();
-  let data: unknown;
-  try {
-    data = text ? JSON.parse(text) : null;
-  } catch {
-    data = text;
-  }
-
-  if (!resp.ok) {
-    const path = new URL(url).pathname;
-    throw new APIError(resp.status, resp.statusText, text, path);
-  }
-
-  return { status: resp.status, headers: resp.headers, data: data as T };
 }

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -5,12 +5,14 @@ export interface GlobalFlags {
   noColor?: boolean;
   quiet?: boolean;
   verbose?: boolean;
+  json?: boolean;
 }
 
 let state: Required<GlobalFlags> = {
   noColor: false,
   quiet: false,
   verbose: false,
+  json: false,
 };
 
 export function configureOutput(flags: GlobalFlags = {}): void {
@@ -23,6 +25,9 @@ export function configureOutput(flags: GlobalFlags = {}): void {
     noColor,
     quiet: flags.quiet === true,
     verbose: flags.verbose === true,
+    // json is sticky: once enabled (e.g. detected before commander parse) it
+    // stays on unless the caller explicitly passes a new value.
+    json: flags.json ?? state.json,
   };
 
   if (noColor) {
@@ -38,22 +43,27 @@ export function isVerbose(): boolean {
   return state.verbose;
 }
 
+export function isJson(): boolean {
+  return state.json;
+}
+
 export function isInteractive(): boolean {
-  return process.stdout.isTTY === true && !state.quiet;
+  return process.stdout.isTTY === true && !state.quiet && !state.json;
 }
 
 export function startSpinner(text: string): Ora | null {
-  if (!isInteractive()) return null;
+  // No spinners in JSON mode or when non-interactive.
+  if (state.json || !isInteractive()) return null;
   return ora({ text, stream: process.stderr }).start();
 }
 
 export function logInfo(msg: string): void {
-  if (state.quiet) return;
+  if (state.quiet || state.json) return;
   process.stderr.write(`${msg}\n`);
 }
 
 export function logVerbose(msg: string): void {
-  if (!state.verbose) return;
+  if (!state.verbose || state.json) return;
   process.stderr.write(`${chalk.dim("[debug]")} ${msg}\n`);
 }
 
@@ -62,6 +72,6 @@ export function logError(msg: string): void {
 }
 
 export function logWarn(msg: string): void {
-  if (state.quiet) return;
+  if (state.quiet || state.json) return;
   process.stderr.write(`${chalk.yellow(msg)}\n`);
 }

--- a/src/lib/runtime.ts
+++ b/src/lib/runtime.ts
@@ -1,0 +1,89 @@
+import { randomBytes } from "node:crypto";
+import { CONFIG } from "./config.js";
+import {
+  readCredentials,
+  withCredentialsLock,
+  updateDeviceIdLocked,
+} from "./creds-store.js";
+
+/**
+ * Per-install device id + awaited runtime initialization (§3.4).
+ *
+ * The device id is resolved ONCE, before any header/API-client construction, and
+ * cached in module state. Header builders read it through {@link getDeviceId},
+ * which throws if {@link initRuntime} has not run — fail-fast rather than
+ * silently sending a shared hardcoded default.
+ *
+ * Precedence: `CHECKERS60_DEVICE_ID` env → persisted `device_id` → generate
+ * `randomBytes(8).hex` once and persist. The env override is used for the session
+ * but is NEVER persisted (it does not overwrite a persisted id). Generation is
+ * serialized by the credential lock so two first-run processes converge to ONE
+ * id; the common path (env set, or already persisted) stays read-only.
+ */
+
+let resolvedDeviceId: string | undefined;
+let initInFlight: Promise<string> | undefined;
+
+/**
+ * Resolve the per-install device id by precedence. Read-only on the common path;
+ * only a true first run (no env, no persisted id) takes the write lock.
+ */
+export async function resolveDeviceId(): Promise<string> {
+  const envId = process.env.CHECKERS60_DEVICE_ID;
+  if (envId) return envId;
+
+  // Read-only fast path: adopt an already-persisted id without locking.
+  const disk = await readCredentials(CONFIG.CREDS_PATH, true).catch(
+    () => ({}) as Awaited<ReturnType<typeof readCredentials>>
+  );
+  if (disk.device_id) return disk.device_id;
+
+  // First run: generate under the lock. Double-check inside the lock so a
+  // concurrent first-run process that persisted first wins, and both converge.
+  return withCredentialsLock(async (ctx) => {
+    const fresh = await ctx.read();
+    if (fresh.device_id) return fresh.device_id;
+    const committed = await updateDeviceIdLocked(ctx, randomBytes(8).toString("hex"));
+    if (!committed.device_id) throw new Error("Failed to persist device id");
+    return committed.device_id;
+  });
+}
+
+/**
+ * Idempotently resolve the device id and store it in module state. Call once,
+ * before any header/API-client construction (a commander `preAction` hook). Safe
+ * to call concurrently — a single in-flight resolution is shared.
+ */
+export function initRuntime(): Promise<string> {
+  if (resolvedDeviceId !== undefined) return Promise.resolve(resolvedDeviceId);
+  if (!initInFlight) {
+    initInFlight = resolveDeviceId()
+      .then((id) => {
+        resolvedDeviceId = id;
+        return id;
+      })
+      .finally(() => {
+        initInFlight = undefined;
+      });
+  }
+  return initInFlight;
+}
+
+/**
+ * The resolved per-install device id. Throws (fail-fast) if {@link initRuntime}
+ * has not resolved it, so no request can ever fall back to a shared default.
+ */
+export function getDeviceId(): string {
+  if (resolvedDeviceId === undefined) {
+    throw new Error(
+      "Runtime not initialized: initRuntime() must resolve the device id before building request headers"
+    );
+  }
+  return resolvedDeviceId;
+}
+
+/** Test-only: reset resolved runtime state so a fresh resolution can be exercised. */
+export function resetRuntimeForTests(): void {
+  resolvedDeviceId = undefined;
+  initInFlight = undefined;
+}


### PR DESCRIPTION
## P0 — headless foundation for agents / devices / claws

Makes checkers60-cli safe to drive unattended at fleet scale. Plan reviewed & approved by Oracle (GPT-5.6 Sol) over 5 rounds; implementation approved over 2 more.

### Stack (6 commits)
- `#23` json-first errors, exit codes (3=auth, 4=network), commander output buffering
- `#24` http external abort signal, body-consumption timeout fix, URL/query redaction (refresh-token leak)
- `#25` locked credential store — proper-lockfile, tx deadline + abort, atomic 0600 writes, field-scoped transactions, refresh reconciliation, logout preserves device_id
- `#26` safe/never retry policy — backoff, Retry-After, overall budget; mutations & pre-order never retried
- `#27` per-install device id resolved at awaited runtime init (fail-fast getter)
- `#29` Oracle final-review fixes — response-body leak, corrupt-file logout, sweep-under-lock, logout JSON

### Verification
- `npm ci && npm run lint && npm run build && npm test` — **93 tests pass**, mirrors CI exactly (Node 22).
- Cross-process concurrency proven with real child-process tests (refresh serialization, device-id convergence).

Closes #23
Closes #24
Closes #25
Closes #26
Closes #27
Closes #29